### PR TITLE
Add ListMedications method

### DIFF
--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -74,7 +74,9 @@ type Client interface {
 	UpdateHealthHistoryFormForAppointment(ctx context.Context, appointmentID, formID string, form *HealthHistoryForm) error
 
 	SearchAllergies(ctx context.Context, searchVal string) ([]*Allergy, error)
-	SearchMedications(ctx context.Context, searchVal string) ([]*Medication, error)
+
+	ListMedications(ctx context.Context, patientID string, opts *ListMedicationsOptions) (*ListMedicationsResult, error)
+	SearchMedications(ctx context.Context, searchVal string) ([]*SearchMedicationsResult, error)
 }
 
 type TokenProvider interface {

--- a/athenahealth/medications.go
+++ b/athenahealth/medications.go
@@ -2,19 +2,100 @@ package athenahealth
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 )
 
+type MedicationEventType string
+
+const (
+	EventTypeStart MedicationEventType = "START"
+	EventTypeEnd   MedicationEventType = "END"
+	EventTypeOrder MedicationEventType = "ORDER"
+	EventTypeEnter MedicationEventType = "ENTER"
+	EventTypeFill  MedicationEventType = "FILL"
+	EventTypeHide  MedicationEventType = "HIDE"
+)
+
+type MedicationEvent struct {
+	EventDate       string              `json:"eventdate"`
+	Type            MedicationEventType `json:"type"`
+	UserDisplayName string              `json:"userdisplayname,omitempty"`
+}
+
+type MedicationStructuredSig struct {
+	DosageAdditionalInstructions string       `json:"dosageadditionalinstructions,omitempty"`
+	DosageFrequencyValue         NumberString `json:"dosagefrequencyvalue,omitempty"`
+	DosageRoute                  string       `json:"dosageroute"`
+	DosageAction                 string       `json:"dosageaction"`
+	DosageFrequencyUnit          string       `json:"dosagefrequencyunit"`
+	DosageQuantityUnit           string       `json:"dosagequantityunit"`
+	DosageQuantityValue          NumberString `json:"dosagequantityvalue"`
+	DosageFrequencyDescription   string       `json:"dosagefrequencydescription"`
+	DosageDurationUnit           string       `json:"dosagedurationunit"`
+	DosageDurationValue          NumberString `json:"dosagedurationvalue"`
+}
+
 type Medication struct {
+	ClinicalOrderTypeID NumberString            `json:"clinicalordertypeid"`
+	CreatedBy           string                  `json:"createdby"`
+	Events              []MedicationEvent       `json:"events"`
+	FDBMedicationID     NumberString            `json:"fdbmedicationid"`
+	IsDiscontinued      bool                    `json:"isdiscontinued"`
+	IsSafeToRenew       bool                    `json:"issafetorenew"`
+	IsStructuredSig     bool                    `json:"isstructuredsig"`
+	LastModifiedBy      string                  `json:"lastmodifiedby,omitempty"`
+	LastModifiedDate    string                  `json:"lastmodifieddate,omitempty"`
+	Medication          string                  `json:"medication"`
+	MedicationEntryID   string                  `json:"medicationentryid"`
+	MedicationID        NumberString            `json:"medicationid"`
+	OrganClass          string                  `json:"organclass"`
+	Source              string                  `json:"source"`
+	StructuredSig       MedicationStructuredSig `json:"structuredsig,omitempty"`
+	UnstructuredSig     string                  `json:"unstructuredsig,omitempty"`
+}
+
+type ListMedicationsResult struct {
+	LastUpdated                 string         `json:"lastupdated"`
+	Medications                 [][]Medication `json:"medications"`
+	NoMedicationsReported       bool           `json:"nomedicationsreported"`
+	PatientDownloadConsent      bool           `json:"patientdownloadconsent"`
+	PatientNeedsDownloadConsent bool           `json:"patientneedsdownloadconsent"`
+}
+
+type ListMedicationsOptions struct {
+	DepartmentID string
+}
+
+type SearchMedicationsResult struct {
 	Medication   string `json:"medication"`
 	MedicationID int    `json:"medicationid"`
+}
+
+// ListMedications - Retrieves a list of medications for a given patient
+// GET /v1/{practiceid}/chart/{patientid}/medications
+// https://docs.athenahealth.com/api/api-ref/medication#Get-patient's-medication-list
+func (h *HTTPClient) ListMedications(ctx context.Context, patientID string, opts *ListMedicationsOptions) (*ListMedicationsResult, error) {
+	out := &ListMedicationsResult{}
+
+	q := url.Values{}
+	if len(opts.DepartmentID) > 0 {
+		q.Add("departmentid", opts.DepartmentID)
+	}
+
+	_, err := h.Get(ctx, fmt.Sprintf("/chart/%s/medications", patientID), q, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }
 
 // SearchMedications - Retrieves a list of medications for a given search parameters.
 // GET /v1/{practiceid}/reference/medications
 // https://docs.athenahealth.com/api/api-ref/medication#Search-for-available-medications
-func (h *HTTPClient) SearchMedications(ctx context.Context, searchVal string) ([]*Medication, error) {
-	out := []*Medication{}
+func (h *HTTPClient) SearchMedications(ctx context.Context, searchVal string) ([]*SearchMedicationsResult, error) {
+	out := []*SearchMedicationsResult{}
 
 	q := url.Values{}
 	q.Add("searchvalue", searchVal)

--- a/athenahealth/medications_test.go
+++ b/athenahealth/medications_test.go
@@ -9,6 +9,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHTTPClient_ListMedications(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+	departmentID := "789"
+	opts := &ListMedicationsOptions{DepartmentID: departmentID}
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(departmentID, r.URL.Query().Get("departmentid"))
+
+		b, _ := os.ReadFile("./resources/ListMedications.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	medicationsResult, err := athenaClient.ListMedications(context.Background(), patientID, opts)
+
+	assert.NotNil(medicationsResult)
+	assert.Len(medicationsResult.Medications, 5)
+	assert.NoError(err)
+}
+
+func TestHTTPClient_ListMedications_None(t *testing.T) {
+	assert := assert.New(t)
+
+	patientID := "123"
+	departmentID := "789"
+	opts := &ListMedicationsOptions{DepartmentID: departmentID}
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(departmentID, r.URL.Query().Get("departmentid"))
+
+		b := []byte(`{
+			"patientneedsdownloadconsent": false,"medications": [],"patientdownloadconsent": true,"nomedicationsreported": false}`)
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	medicationsResult, err := athenaClient.ListMedications(context.Background(), patientID, opts)
+
+	assert.NotNil(medicationsResult)
+	assert.Len(medicationsResult.Medications, 0)
+	assert.NoError(err)
+}
+
 func TestHTTPClient_SearchMedications(t *testing.T) {
 	assert := assert.New(t)
 

--- a/athenahealth/resources/ListMedications.json
+++ b/athenahealth/resources/ListMedications.json
@@ -1,0 +1,184 @@
+{
+  "patientneedsdownloadconsent": false,
+  "lastupdated": "03/16/2023",
+  "medications": [
+      [
+          {
+              "clinicalordertypeid": "193884",
+              "organclass": "NERVOUS SYSTEM (EXCEPT AUTONOMIC)",
+              "fdbmedicationid": "182394",
+              "medicationid": 231555,
+              "therapeuticclass": "OPIOID ANTAGONISTS",
+              "isdiscontinued": false,
+              "issafetorenew": true,
+              "medicationentryid": "H228145",
+              "structuredsig": {
+                  "dosagefrequencyvalue": 1,
+                  "dosageroute": "oral",
+                  "dosageaction": "TAKE",
+                  "dosagefrequencyunit": "per day",
+                  "dosagequantityunit": "tablet(s)",
+                  "dosagequantityvalue": 1,
+                  "dosagefrequencydescription": "every day",
+                  "dosagedurationunit": "day"
+              },
+              "medication": "naltrexone 50 mg tablet",
+              "unstructuredsig": "Take 1 tablet every day by oral route.",
+              "lastmodifiedby": "myathenausername",
+              "source": "Staff Stafferson",
+              "createdby": "myathenausername",
+              "isstructuredsig": true,
+              "events": [
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "HIDE"
+                  },
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "ENTER",
+                      "userdisplayname": "Staff Stafferson"
+                  },
+                  {
+                      "eventdate": "03/14/2023",
+                      "type": "END"
+                  }
+              ],
+              "lastmodifieddate": "03/16/2023"
+          }
+      ],
+      [
+          {
+              "clinicalordertypeid": "203784",
+              "organclass": "NERVOUS SYSTEM (EXCEPT AUTONOMIC)",
+              "fdbmedicationid": "226373",
+              "medicationid": 241444,
+              "therapeuticclass": "ANTI-ANXIETY - BENZODIAZEPINES",
+              "isdiscontinued": false,
+              "issafetorenew": true,
+              "medicationentryid": "H228147",
+              "medication": "Valium 2 mg tablet",
+              "source": "Staff Stafferson",
+              "createdby": "myathenausername",
+              "isstructuredsig": false,
+              "events": [
+                  {
+                      "eventdate": "03/14/2023",
+                      "type": "START"
+                  },
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "ENTER",
+                      "userdisplayname": "Staff Stafferson"
+                  }
+              ]
+          }
+      ],
+      [
+          {
+              "clinicalordertypeid": "205767",
+              "organclass": "NERVOUS SYSTEM (EXCEPT AUTONOMIC)",
+              "fdbmedicationid": "235411",
+              "medicationid": 243333,
+              "therapeuticclass": "ANTI-ANXIETY - BENZODIAZEPINES",
+              "isdiscontinued": false,
+              "issafetorenew": true,
+              "medicationentryid": "H228148",
+              "structuredsig": {
+                  "dosagefrequencyvalue": 1,
+                  "dosageroute": "oral",
+                  "dosageaction": "TAKE",
+                  "dosageadditionalinstructions": "with meals",
+                  "dosagedurationvalue": 30,
+                  "dosagefrequencyunit": "per day",
+                  "dosagequantityunit": "tablet(s)",
+                  "dosagequantityvalue": 2,
+                  "dosagefrequencydescription": "every day",
+                  "dosagedurationunit": "day"
+              },
+              "medication": "Xanax 0.25 mg tablet",
+              "unstructuredsig": "Take 2 tablets every day by oral route with meals for 30 days.",
+              "source": "Staff Stafferson",
+              "createdby": "myathenausername",
+              "isstructuredsig": true,
+              "providernote": "Medication note goes here!",
+              "events": [
+                  {
+                      "eventdate": "03/17/2023",
+                      "type": "START"
+                  },
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "ENTER",
+                      "userdisplayname": "Staff Stafferson"
+                  }
+              ]
+          }
+      ],
+      [
+          {
+              "clinicalordertypeid": "238718",
+              "organclass": "NERVOUS SYSTEM (EXCEPT AUTONOMIC)",
+              "fdbmedicationid": "445975",
+              "medicationid": 276333,
+              "therapeuticclass": "SELECTIVE SEROTONIN REUPTAKE INHIBITOR (SSRIS)",
+              "isdiscontinued": false,
+              "issafetorenew": true,
+              "medicationentryid": "H228146",
+              "medication": "Lexapro 10 mg tablet",
+              "unstructuredsig": "TAKE 1 TABLET (10 MG) BY ORAL ROUTE ONCE DAILY",
+              "source": "Staff Stafferson",
+              "createdby": "myathenausername",
+              "isstructuredsig": false,
+              "events": [
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "ENTER",
+                      "userdisplayname": "Staff Stafferson"
+                  }
+              ]
+          }
+      ],
+      [
+          {
+              "clinicalordertypeid": "353521",
+              "organclass": "AUTONOMIC NERVOUS SYSTEM",
+              "fdbmedicationid": "582580",
+              "medicationid": 375444,
+              "therapeuticclass": "ANTI-OBESITY-OPIOID ANTAG-NOREPI,DOPAMINE RU INHIB",
+              "isdiscontinued": false,
+              "issafetorenew": true,
+              "medicationentryid": "H228144",
+              "structuredsig": {
+                  "dosagefrequencyvalue": 2,
+                  "dosageroute": "oral",
+                  "dosageaction": "TAKE",
+                  "dosageadditionalinstructions": "with meals",
+                  "dosagedurationvalue": 30,
+                  "dosagefrequencyunit": "per day",
+                  "dosagequantityunit": "tablet(s)",
+                  "dosagequantityvalue": 2,
+                  "dosagefrequencydescription": "twice a day",
+                  "dosagedurationunit": "day"
+              },
+              "medication": "naltrexone 8 mg-bupropion 90 mg tablet,extended release",
+              "unstructuredsig": "Take 2 tablets twice a day by oral route with meals for 30 days.",
+              "source": "Staff Stafferson",
+              "createdby": "myathenausername",
+              "isstructuredsig": true,
+              "events": [
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "START"
+                  },
+                  {
+                      "eventdate": "03/16/2023",
+                      "type": "ENTER",
+                      "userdisplayname": "Staff Stafferson"
+                  }
+              ]
+          }
+      ]
+  ],
+  "patientdownloadconsent": true,
+  "nomedicationsreported": false
+}


### PR DESCRIPTION
## Overview

Add a `ListMedications` method that calls [GET patient's medications list](https://docs.athenahealth.com/api/api-ref/medication#Get-patient's-medication-list)

## Version Notes

* ❗ This converts the Medications Search response (previously named `Medication`) to a type more descriptive of that response, which doesn't contain full structured medication objects. Calling clients will need to be updated when they access the latest version.