### PR TITLE
add error context for rate limit event

### DIFF
--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -180,7 +180,7 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		if errors.Is(err, ratelimiter.ErrRateExceeded) {
 			select {
 			case <-ctx.Done():
-				return nil, fmt.Errorf("waiting for rate limit timeout: %w", ctx.Err())
+				return nil, fmt.Errorf("waiting for rate limit retry interval: %w", ctx.Err())
 
 			case <-time.After(retryAfter):
 				ctx = context.WithValue(ctx, ctxKeyRateLimitEncountered, struct{}{})

--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -305,13 +305,12 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 }
 
 func (h *HTTPClient) log() *zerolog.Logger {
-	logger := h.logger
-	if logger == nil {
+	if h.logger == nil {
 		noplogger := zerolog.Nop()
-		logger = &noplogger
+		h.logger = &noplogger
 	}
 
-	return logger
+	return h.logger
 }
 
 func (h *HTTPClient) WithLogger(logger *zerolog.Logger) *HTTPClient {


### PR DESCRIPTION
In order to provide better insight around context deadline exceeded events, this PR adds error context.