### PR TITLE
Add clinical document

### DIFF
--- a/athenahealth/documents.go
+++ b/athenahealth/documents.go
@@ -199,7 +199,7 @@ type AddClinicalDocumentOptions struct {
 	ProviderID         *int
 }
 
-type addClinicalDocumentResponse struct {
+type AddClinicalDocumentResponse struct {
 	ClinicalDocumentID int `json:"clinicaldocumentid"`
 }
 

--- a/athenahealth/documents.go
+++ b/athenahealth/documents.go
@@ -181,6 +181,111 @@ func (h *HTTPClient) AddDocument(ctx context.Context, patientID string, opts *Ad
 	return res.DocumentID, nil
 }
 
+type AddClinicalDocumentOptions struct {
+	AttachmentContents []byte
+	AttachmentType     *string
+	AutoClose          *string
+	ClinicalProviderID *int
+	DepartmentID       *int
+	DocumentData       *string
+	DocumentSubclass   string
+	DocumentTypeID     *int
+	EntityID           *int
+	EntityType         *string
+	InternalNote       *string
+	ObservationDate    *string
+	ObservationTime    *string
+	OriginalFileName   *string
+	ProviderID         *int
+}
+
+type addClinicalDocumentResponse struct {
+	ClinicalDocumentID int `json:"clinicaldocumentid"`
+}
+
+// AddClinicalDocument - Add clinical document to patient's chart
+//
+// POST /v1/{practiceid}/patients/{patientid}/documents/clinicaldocument
+//
+// https://docs.athenahealth.com/api/api-ref/document-type-clinical-document#Add-clinical-document-to-patient's-chart
+func (h *HTTPClient) AddClinicalDocument(ctx context.Context, patientID string, opts *AddClinicalDocumentOptions) (int, error) {
+	var form url.Values
+
+	if opts != nil {
+		form = url.Values{}
+
+		form.Add("attachmentcontents", base64.StdEncoding.EncodeToString(opts.AttachmentContents))
+
+		if opts.AttachmentType != nil {
+			form.Add("attachmenttype", *opts.AttachmentType)
+		}
+
+		if opts.AutoClose != nil {
+			form.Add("autoclose", *opts.AutoClose)
+		}
+
+		if opts.ClinicalProviderID != nil {
+			clinicalProviderID := strconv.Itoa(*opts.ClinicalProviderID)
+			form.Add("clinicalproviderid", clinicalProviderID)
+		}
+
+		if opts.DepartmentID != nil {
+			deptID := strconv.Itoa(*opts.DepartmentID)
+			form.Add("departmentid", deptID)
+		}
+
+		if opts.DocumentData != nil {
+			form.Add("documentdata", *opts.DocumentData)
+		}
+
+		form.Add("documentsubclass", opts.DocumentSubclass)
+
+		if opts.DocumentTypeID != nil {
+			documentTypeID := strconv.Itoa(*opts.DocumentTypeID)
+			form.Add("documenttypeid", documentTypeID)
+		}
+
+		if opts.EntityID != nil {
+			entityID := strconv.Itoa(*opts.EntityID)
+			form.Add("entityid", entityID)
+		}
+
+		if opts.EntityType != nil {
+			form.Add("entitytype", *opts.EntityType)
+		}
+
+		if opts.InternalNote != nil {
+			form.Add("internalnote", *opts.InternalNote)
+		}
+
+		if opts.ObservationDate != nil {
+			form.Add("observationdate", *opts.ObservationDate)
+		}
+
+		if opts.ObservationTime != nil {
+			form.Add("observationtime", *opts.ObservationTime)
+		}
+
+		if opts.OriginalFileName != nil {
+			form.Add("originalfilename", *opts.OriginalFileName)
+		}
+
+		if opts.ProviderID != nil {
+			providerID := strconv.Itoa(*opts.ProviderID)
+			form.Add("providerid", providerID)
+		}
+	}
+
+	res := &addClinicalDocumentResponse{}
+
+	_, err := h.PostForm(ctx, fmt.Sprintf("/patients/%s/documents/clinicaldocument", patientID), form, res)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.ClinicalDocumentID, nil
+}
+
 type AddPatientCaseDocumentOptions struct {
 	AutoClose          *bool
 	CallbackName       *string

--- a/athenahealth/documents_test.go
+++ b/athenahealth/documents_test.go
@@ -88,6 +88,53 @@ func TestHTTPClient_AddDocument(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestHTTPClient_AddClinicalDocument(t *testing.T) {
+	assert := assert.New(t)
+
+	attachmentContents := []byte("test attachment contents")
+	autoclose := "true"
+	deptID := 2
+	documentSubclass := "CLINICALDOCUMENT"
+	internalNote := "test internal note"
+	providerID := 3
+	documentTypeId := 4
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(r.ParseForm())
+
+		assert.Contains(r.URL.Path, "/patients/123/documents/clinicaldocument")
+
+		assert.Equal(base64.StdEncoding.EncodeToString([]byte(attachmentContents)), r.FormValue("attachmentcontents"))
+		assert.Equal(autoclose, r.FormValue("autoclose"))
+		assert.Equal(strconv.Itoa(deptID), r.FormValue("departmentid"))
+		assert.Equal(documentSubclass, r.FormValue("documentsubclass"))
+		assert.Equal(internalNote, r.FormValue("internalnote"))
+		assert.Equal(strconv.Itoa(providerID), r.FormValue("providerid"))
+		assert.Equal(strconv.Itoa(documentTypeId), r.FormValue("documenttypeid"))
+
+		b, _ := os.ReadFile("./resources/AddClinicalDocument.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	opts := &AddClinicalDocumentOptions{
+		AttachmentContents: attachmentContents,
+		AutoClose:          &autoclose,
+		DepartmentID:       &deptID,
+		DocumentSubclass:   documentSubclass,
+		InternalNote:       &internalNote,
+		ProviderID:         &providerID,
+		DocumentTypeID:     &documentTypeId,
+	}
+
+	clinicalDocumentID, err := athenaClient.AddClinicalDocument(context.Background(), "123", opts)
+
+	assert.Equal(101, clinicalDocumentID)
+	assert.NoError(err)
+}
+
 func TestHTTPClient_AddPatientCaseDocument(t *testing.T) {
 	assert := assert.New(t)
 

--- a/athenahealth/documents_test.go
+++ b/athenahealth/documents_test.go
@@ -102,7 +102,7 @@ func TestHTTPClient_AddClinicalDocument(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.NoError(r.ParseForm())
 
-		assert.Contains(r.URL.Path, "/patients/123/documents/clinicaldocument")
+		assert.Equal(r.URL.Path, "/patients/123/documents/clinicaldocument")
 
 		assert.Equal(base64.StdEncoding.EncodeToString([]byte(attachmentContents)), r.FormValue("attachmentcontents"))
 		assert.Equal(autoclose, r.FormValue("autoclose"))
@@ -122,16 +122,17 @@ func TestHTTPClient_AddClinicalDocument(t *testing.T) {
 	opts := &AddClinicalDocumentOptions{
 		AttachmentContents: attachmentContents,
 		AutoClose:          &autoclose,
-		DepartmentID:       &deptID,
+		DepartmentID:       deptID,
 		DocumentSubclass:   documentSubclass,
 		InternalNote:       &internalNote,
 		ProviderID:         &providerID,
 		DocumentTypeID:     &documentTypeId,
 	}
 
-	clinicalDocumentID, err := athenaClient.AddClinicalDocument(context.Background(), "123", opts)
+	res, err := athenaClient.AddClinicalDocument(context.Background(), "123", opts)
 
-	assert.Equal(101, clinicalDocumentID)
+	assert.Equal(101, res.ClinicalDocumentID)
+	assert.True(res.Success)
 	assert.NoError(err)
 }
 

--- a/athenahealth/resources/AddClinicalDocument.json
+++ b/athenahealth/resources/AddClinicalDocument.json
@@ -1,3 +1,4 @@
 {
+    "success": true,
     "clinicaldocumentid": 101
 }

--- a/athenahealth/resources/AddClinicalDocument.json
+++ b/athenahealth/resources/AddClinicalDocument.json
@@ -1,0 +1,3 @@
+{
+    "clinicaldocumentid": 101
+}


### PR DESCRIPTION
Includes the ability to add clinical document's to patient's chart.
Included under `documents.go`, but LMK if it is better to split it into it's own `clinical_documents.go` file
API DOCS: https://docs.athenahealth.com/api/api-ref/document-type-clinical-document#Add-clinical-document-to-patient's-chart

Unit and integration tested 