### PR TITLE
1/3 make TestClient public to allow mocking and overriding baseURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-all: tidy format build test
+all: tidy format build lint test
 
 build:
 	go build ./...
 
 format:
 	go fmt ./...
+
+lint:
+	golangci-lint run --timeout=5m --tests=false
 
 test:
 	go test ./...

--- a/athenahealth/allergies_test.go
+++ b/athenahealth/allergies_test.go
@@ -21,7 +21,7 @@ func TestHTTPClient_SearchAllergies(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	allergies, err := athenaClient.SearchAllergies(context.Background(), searchVal)
@@ -43,7 +43,7 @@ func TestHTTPClient_SearchAllergies_None(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	allergies, err := athenaClient.SearchAllergies(context.Background(), searchVal)

--- a/athenahealth/appointment_slots_test.go
+++ b/athenahealth/appointment_slots_test.go
@@ -36,7 +36,7 @@ func TestHTTPClient_CreateAppointmentSlot(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	createAppointmentSlotResult, err := athenaClient.CreateAppointmentSlot(context.Background(), opts)

--- a/athenahealth/appointment_types_test.go
+++ b/athenahealth/appointment_types_test.go
@@ -35,7 +35,7 @@ func TestHTTPClient_CreateAppointmentType(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	createAppointmentTypeResult, err := athenaClient.CreateAppointmentType(context.Background(), opts)

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -21,7 +21,7 @@ func TestHTTPClient_GetAppointment(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	appointment, err := athenaClient.GetAppointment(context.Background(), "1")
@@ -38,7 +38,7 @@ func TestHTTPClient_ListAppointmentCustomFields(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	customFields, err := athenaClient.ListAppointmentCustomFields(context.Background())
@@ -60,7 +60,7 @@ func TestHTTPClient_ListBookedAppointments(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListBookedAppointmentsOptions{
@@ -91,7 +91,7 @@ func TestHTTPClient_ListChangedAppointments(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListChangedAppointmentsOptions{
@@ -119,7 +119,7 @@ func TestHTTPClient_CreateAppointmentNote(t *testing.T) {
 		called = true
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &CreateAppointmentNoteOptions{
@@ -143,7 +143,7 @@ func TestHTTPClient_ListAppointmentNotes(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListAppointmentNotesOptions{
@@ -170,7 +170,7 @@ func TestHTTPClient_UpdateAppointmentNote(t *testing.T) {
 		called = true
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &UpdateAppointmentNoteOptions{
@@ -198,7 +198,7 @@ func TestHTTPClient_DeleteAppointmentNote(t *testing.T) {
 		called = true
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &DeleteAppointmentNoteOptions{
@@ -250,7 +250,7 @@ func TestHTTPClient_ListOpenAppointmentSlots(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	slotsRes, err := athenaClient.ListOpenAppointmentSlots(context.Background(), deptID, opts)
@@ -293,7 +293,7 @@ func TestHTTPClient_BookAppointment(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	_, err := athenaClient.BookAppointment(context.Background(), patientID, apptID, opts)
@@ -330,7 +330,7 @@ func TestHTTPClient_RescheduleAppointment(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	rescheduleAppointmentResult, err := athenaClient.RescheduleAppointment(context.Background(), 998877, opts)

--- a/athenahealth/charts_test.go
+++ b/athenahealth/charts_test.go
@@ -21,7 +21,7 @@ func TestHTTPClient_ListSocialHistoryTemplates(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	templates, err := athenaClient.ListSocialHistoryTemplates(context.Background())
@@ -43,7 +43,7 @@ func TestHTTPClient_GetPatientSocialHistory(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &GetPatientSocialHistoryOptions{
@@ -83,7 +83,7 @@ func TestHTTPClient_UpdatePatientSocialHistory(t *testing.T) {
 		called = true
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &UpdatePatientSocialHistoryOptions{

--- a/athenahealth/claims_test.go
+++ b/athenahealth/claims_test.go
@@ -99,7 +99,7 @@ func TestHTTPClient_CreateClaim(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	claimIDs, err := athenaClient.CreateFinancialClaim(context.Background(), opts)
@@ -139,7 +139,7 @@ func TestHTTPClient_ListClaims(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	res, err := athenaClient.ListClaims(context.Background(), opts)

--- a/athenahealth/customfields_test.go
+++ b/athenahealth/customfields_test.go
@@ -17,7 +17,7 @@ func TestHTTPClient_ListCustomFields(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	customFields, err := athenaClient.ListCustomFields(context.Background())

--- a/athenahealth/departments_test.go
+++ b/athenahealth/departments_test.go
@@ -17,7 +17,7 @@ func TestHTTPClient_GetDepartment(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	department, err := athenaClient.GetDepartment(context.Background(), "1")
@@ -38,7 +38,7 @@ func TestHTTPClient_ListDepartments(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListDepartmentsOptions{

--- a/athenahealth/documents_test.go
+++ b/athenahealth/documents_test.go
@@ -23,7 +23,7 @@ func TestHTTPClient_ListAdminDocuments(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListAdminDocumentsOptions{
@@ -69,7 +69,7 @@ func TestHTTPClient_AddDocument(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &AddDocumentOptions{
@@ -113,7 +113,7 @@ func TestHTTPClient_AddDocumentReader(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &AddDocumentReaderOptions{
@@ -162,7 +162,7 @@ func TestHTTPClient_AddClinicalDocument(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &AddClinicalDocumentOptions{
@@ -218,7 +218,7 @@ func TestHTTPClient_AddPatientCaseDocument(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &AddPatientCaseDocumentOptions{

--- a/athenahealth/health_history_forms_test.go
+++ b/athenahealth/health_history_forms_test.go
@@ -25,7 +25,7 @@ func TestHTTPClient_GetHealthHistoryFormForAppointment(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	hhf, err := athenaClient.GetHealthHistoryFormForAppointment(context.Background(), apptID, formID)
@@ -58,7 +58,7 @@ func TestHTTPClient_UpdateHealthHistoryFormForAppointment(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	err = athenaClient.UpdateHealthHistoryFormForAppointment(context.Background(), apptID, formID, hhf)

--- a/athenahealth/httptestclient.go
+++ b/athenahealth/httptestclient.go
@@ -1,0 +1,97 @@
+package athenahealth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+const (
+	testPracticeID = "123456"
+	testAPIKey     = "api-key"
+	testAPISecret  = "api-secret"
+)
+
+func TestClient(h http.HandlerFunc) (*HTTPClient, *httptest.Server) {
+	if h == nil {
+		h = func(w http.ResponseWriter, r *http.Request) {
+			b, _ := json.Marshal(nil)
+			w.Header().Add("Content-Type", "application/json")
+			w.Write(b)
+		}
+	}
+
+	ts := httptest.NewServer(h)
+
+	athenaClient := NewHTTPClient(ts.Client(), testPracticeID, testAPIKey, testAPISecret).
+		WithTokenProvider(&testTokenProvider{}).
+		WithTokenCacher(&testTokenCacher{})
+
+	athenaClient.baseURL = ts.URL
+
+	return athenaClient, ts
+}
+
+const testToken = "token"
+
+type testTokenProvider struct {
+}
+
+func (t *testTokenProvider) Provide(ctx context.Context) (string, time.Time, error) {
+	return testToken, time.Now().Add(time.Minute * 1), nil
+}
+
+type testTokenCacher struct {
+}
+
+func (t *testTokenCacher) Get(ctx context.Context) (string, error) {
+	return testToken, nil
+}
+
+func (t *testTokenCacher) Set(context.Context, string, time.Time) error {
+	return nil
+}
+
+type testRateLimiter struct {
+	AllowedFunc func(preview bool) (time.Duration, error)
+}
+
+func (t *testRateLimiter) Allowed(ctx context.Context, preview bool) (time.Duration, error) {
+	if t.AllowedFunc != nil {
+		return t.AllowedFunc(preview)
+	}
+
+	return 0, nil
+}
+
+type testStats struct {
+	RequestFunc         func(method, path string) error
+	ResponseSuccessFunc func() error
+	ResponseErrorFunc   func() error
+}
+
+func (t *testStats) Request(method, path string) error {
+	if t.RequestFunc != nil {
+		return t.RequestFunc(method, path)
+	}
+
+	return nil
+}
+
+func (t *testStats) ResponseSuccess() error {
+	if t.ResponseSuccessFunc != nil {
+		return t.ResponseSuccessFunc()
+	}
+
+	return nil
+}
+
+func (t *testStats) ResponseError() error {
+	if t.ResponseErrorFunc != nil {
+		return t.ResponseErrorFunc()
+	}
+
+	return nil
+}

--- a/athenahealth/httptestclient.go
+++ b/athenahealth/httptestclient.go
@@ -19,7 +19,7 @@ func TestClient(h http.HandlerFunc) (*HTTPClient, *httptest.Server) {
 		h = func(w http.ResponseWriter, r *http.Request) {
 			b, _ := json.Marshal(nil)
 			w.Header().Add("Content-Type", "application/json")
-			w.Write(b)
+			_, _ = w.Write(b)
 		}
 	}
 
@@ -54,11 +54,11 @@ func (t *testTokenCacher) Set(context.Context, string, time.Time) error {
 	return nil
 }
 
-type testRateLimiter struct {
+type testRateLimiter struct { //nolint:unused
 	AllowedFunc func(preview bool) (time.Duration, error)
 }
 
-func (t *testRateLimiter) Allowed(ctx context.Context, preview bool) (time.Duration, error) {
+func (t *testRateLimiter) Allowed(ctx context.Context, preview bool) (time.Duration, error) { //nolint:unused
 	if t.AllowedFunc != nil {
 		return t.AllowedFunc(preview)
 	}
@@ -66,13 +66,13 @@ func (t *testRateLimiter) Allowed(ctx context.Context, preview bool) (time.Durat
 	return 0, nil
 }
 
-type testStats struct {
+type testStats struct { //nolint: unused
 	RequestFunc         func(method, path string) error
 	ResponseSuccessFunc func() error
 	ResponseErrorFunc   func() error
 }
 
-func (t *testStats) Request(method, path string) error {
+func (t *testStats) Request(method, path string) error { // nolint: unused
 	if t.RequestFunc != nil {
 		return t.RequestFunc(method, path)
 	}
@@ -80,7 +80,7 @@ func (t *testStats) Request(method, path string) error {
 	return nil
 }
 
-func (t *testStats) ResponseSuccess() error {
+func (t *testStats) ResponseSuccess() error { // nolint: unused
 	if t.ResponseSuccessFunc != nil {
 		return t.ResponseSuccessFunc()
 	}
@@ -88,7 +88,7 @@ func (t *testStats) ResponseSuccess() error {
 	return nil
 }
 
-func (t *testStats) ResponseError() error {
+func (t *testStats) ResponseError() error { // nolint: unused
 	if t.ResponseErrorFunc != nil {
 		return t.ResponseErrorFunc()
 	}

--- a/athenahealth/insurance_test.go
+++ b/athenahealth/insurance_test.go
@@ -43,7 +43,7 @@ func TestHTTPClient_CreatePatientInsurancePackage(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	_, err := athenaClient.CreatePatientInsurancePackage(context.Background(), opts)
@@ -84,7 +84,7 @@ func TestHTTPClient_UpdatePatientInsurancePackage(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	err := athenaClient.UpdatePatientInsurancePackage(context.Background(), opts)
@@ -109,7 +109,7 @@ func TestHTTPClient_DeletePatientInsurancePackage(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	err := athenaClient.DeletePatientInsurancePackage(context.Background(), "1", "2", cancellationNote)
@@ -136,7 +136,7 @@ func TestHTTPClient_ReactivatePatientInsurancePackage(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	err := athenaClient.ReactivatePatientInsurancePackage(context.Background(), patientID, insuranceID, &expDate)
@@ -161,7 +161,7 @@ func TestHTTPClient_ListPatientInsurancePackages(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	res, err := athenaClient.ListPatientInsurancePackages(context.Background(), opts)
@@ -189,7 +189,7 @@ func TestHTTPClient_UploadPatientInsuranceCardImage(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &UploadPatientInsuranceCardImageOptions{
@@ -216,7 +216,7 @@ func TestHTTPClient_GetPatientInsurancePackage(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	res, err := athenaClient.GetPatientInsuranceCardImage(context.Background(), "1", "2")

--- a/athenahealth/medications_test.go
+++ b/athenahealth/medications_test.go
@@ -24,7 +24,7 @@ func TestHTTPClient_ListMedications(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	medicationsResult, err := athenaClient.ListMedications(context.Background(), patientID, opts)
@@ -51,7 +51,7 @@ func TestHTTPClient_ListMedications_None(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	medicationsResult, err := athenaClient.ListMedications(context.Background(), patientID, opts)
@@ -73,7 +73,7 @@ func TestHTTPClient_SearchMedications(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	medications, err := athenaClient.SearchMedications(context.Background(), searchVal)
@@ -95,7 +95,7 @@ func TestHTTPClient_SearchMedications_None(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	meds, err := athenaClient.SearchAllergies(context.Background(), searchVal)

--- a/athenahealth/patients_test.go
+++ b/athenahealth/patients_test.go
@@ -26,7 +26,7 @@ func TestHTTPClient_GetPatient(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	id := "1"
@@ -55,7 +55,7 @@ func TestHTTPClient_ListPatients(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListPatientsOptions{
@@ -80,7 +80,7 @@ func TestHTTPClient_GetPatientPhoto_JPEGOutputNotSupported(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	id := "1"
@@ -103,7 +103,7 @@ func TestHTTPClient_UpdatePatientPhoto(t *testing.T) {
 		assert.Equal(base64.StdEncoding.EncodeToString(data), r.Form.Get("image"))
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	id := "1"
@@ -127,7 +127,7 @@ func TestHTTPClient_ListChangedPatients(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListChangedPatientOptions{
@@ -178,7 +178,7 @@ func TestHTTPClient_UpdatePatientInformationVerificationDetails(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &UpdatePatientInformationVerificationDetailsOptions{
@@ -212,7 +212,7 @@ func TestHTTPClient_GetPatientCustomFields(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	customFields, err := athenaClient.GetPatientCustomFields(context.Background(), patientID, departmentID)
@@ -255,7 +255,7 @@ func TestHTTPClient_UpdatePatientCustomFields(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	err := athenaClient.UpdatePatientCustomFields(context.Background(), patientID, departmentID, customFields)
@@ -278,7 +278,7 @@ func TestHTTPClient_ListPatientsMatchingCustomField(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	res, err := athenaClient.ListPatientsMatchingCustomField(context.Background(), opts)
@@ -343,7 +343,7 @@ func TestHTTPClient_CreatePatient(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	actualPatientID, err := athenaClient.CreatePatient(context.Background(), opts)
@@ -461,7 +461,7 @@ func TestHTTPClient_UpdatePatient(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	result, err := athenaClient.UpdatePatient(context.Background(), "100", opts)

--- a/athenahealth/problems_test.go
+++ b/athenahealth/problems_test.go
@@ -22,7 +22,7 @@ func TestHTTPClient_ListProblems(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListProblemsOptions{
@@ -50,7 +50,7 @@ func TestHTTPClient_ListChangedProblems(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListChangedProblemsOptions{

--- a/athenahealth/providers_test.go
+++ b/athenahealth/providers_test.go
@@ -18,7 +18,7 @@ func TestHTTPClient_GetProvider(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	provider, err := athenaClient.GetProvider(context.Background(), "1")
@@ -39,7 +39,7 @@ func TestHTTPClient_ListChangedProviders(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListChangedProviderOptions{
@@ -64,7 +64,7 @@ func TestHTTPClient_ListProviders(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &ListProvidersOptions{

--- a/athenahealth/subscriptions_test.go
+++ b/athenahealth/subscriptions_test.go
@@ -18,7 +18,7 @@ func TestHTTPClient_GetSubscription(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	subscription, err := athenaClient.GetSubscription(context.Background(), "appointments")
@@ -35,7 +35,7 @@ func TestHTTPClient_ListSubscriptionEvents(t *testing.T) {
 		w.Write(b)
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	events, err := athenaClient.ListSubscriptionEvents(context.Background(), "appointments")
@@ -57,7 +57,7 @@ func TestHTTPClient_Subscribe(t *testing.T) {
 		called = true
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &SubscribeOptions{
@@ -82,7 +82,7 @@ func TestHTTPClient_Unsubscribe(t *testing.T) {
 		called = true
 	}
 
-	athenaClient, ts := testClient(h)
+	athenaClient, ts := TestClient(h)
 	defer ts.Close()
 
 	opts := &UnsubscribeOptions{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/davecgh/go-spew v1.1.1
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-redis/redis_rate/v9 v9.1.2
 	github.com/google/uuid v1.3.0
@@ -26,6 +25,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gomodule/redigo v1.8.9 // indirect
 	github.com/kr/text v0.2.0 // indirect


### PR DESCRIPTION
I can't access baseURL in my mock go-athenahealth client and I can't call `testClient` because it's private and defined in a test file.

Because I can't reach baseURL - my local unit tests that instantiate a HTTP Test Client always try to call either the preview URL or the prod URL because the `h.baseURL` is set privately everywhere.

The crucial lines that I don't have access to are:

```
func testClient(h http.HandlerFunc) (*HTTPClient, *httptest.Server) {
...
...
	ts := httptest.NewServer(h)

	athenaClient := NewHTTPClient(ts.Client(), testPracticeID, testAPIKey, testAPISecret).
		WithTokenProvider(&testTokenProvider{}).
		WithTokenCacher(&testTokenCacher{})

	athenaClient.baseURL = ts.URL // there's no public access to this that I can find and `testClient` is a test function
```