### PR TITLE
Add contributing guide and PR template

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Welcome to the go-athenahealth contributing guide <!-- omit in toc -->
+
+Thank you for investing your time in contributing to our project!
+
+This project is still in early stages (not yet major version 1), so the contributing process is fairly simple.
+
+## Getting started
+
+To get an overview of the project, read the [README](../README.md).
+
+### Make Changes
+
+1. Fork or clone the repository.
+2. Install or update to **Go**, at the version specified in `go.mod`.
+3. Create a working branch and start with your changes! There are no specific requirements for branch naming at this time.
+
+### Commit your update
+
+Commit the changes once you are happy with them. There are no specific requirements for commit format at this time.
+
+### Pull Request
+
+When you're finished with the changes, create a pull request (PR).
+
+- Fill out the [pull request template](./pull_request_template.md) so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request. Note that any breaking changes should be called out in your pull request description.
+- We may ask for changes to be made before a PR can be merged, either using suggested changes or pull request comments.
+- As you update your PR and apply changes, mark each conversation as resolved.
+- If someone has requested changes on your pull request and you believe you have made all necessary changes you can re-request review from that person using the "Reviewers" feature.
+
+### Your PR is merged!
+
+Congratulations! :tada: The Eleanor Health team thanks you :sparkles:
+
+Once your PR is merged, your contributions will be publicly visible on the [go-athenahealth repository](https://github.com/eleanorhealth/go-athenahealth).

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,4 @@
-## {{Ticket Link or Heading}}
+## {{Descriptive Heading}}
 
 Please include a brief description of changes made and rationale here.
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,7 @@
+## {{Ticket Link or Heading}}
+
+Please include a brief description of changes made and rationale here.
+
+## Breaking Changes
+
+If this PR contains breaking changes, please identify them here and provide examples of how calling code should change to accommodate changes.


### PR DESCRIPTION
Per guild discussion, add lightweight contributing guide and PR template, particularly to emphasize the process for breaking changes. Based on [the GitHub docs contributing guide ](https://github.com/github/docs/blob/2e2ab6ec01c83b8035d34e3acfd5ce4d097c2208/CONTRIBUTING.md)

Contributing guides: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors 

Pull request templates: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository