### PR TITLE
(2 of 2) Increase consistency across the appointments endpoints

### DIFF
--- a/athenahealth/appointment_checkin_checkout.go
+++ b/athenahealth/appointment_checkin_checkout.go
@@ -68,7 +68,7 @@ func (h *HTTPClient) AppointmentCheckOut(ctx context.Context, apptID string) err
 	return nil
 }
 
-// StartCheckInAppointment starts the check in process for the provider and patient who are previously booked for the appointment ID
+// AppointmentStartCheckIn starts the check in process for the provider and patient who are previously booked for the appointment ID
 // POST /v1/{practiceid}/appointments/{appointmentid}/startcheckin
 // https://docs.athenahealth.com/api/api-ref/appointment-check-in#Initiate-appointment-check-in-process
 func (h *HTTPClient) AppointmentStartCheckIn(ctx context.Context, apptID string) error {

--- a/athenahealth/appointment_slots.go
+++ b/athenahealth/appointment_slots.go
@@ -2,18 +2,24 @@ package athenahealth
 
 import (
 	"context"
+	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
 type CreateAppointmentSlotOptions struct {
-	AppointmentDate   string   `json:"appointmentdate"`
-	AppointmentTime   []string `json:"appointmenttime"`
-	AppointmentTypeID *int     `json:"appointmenttypeid"`
-	DepartmentID      int      `json:"departmentid"`
-	ProviderID        int      `json:"providerid"`
-	ReasonID          *int     `json:"reasonid"`
+	// The appointment date for the new open appointment slot (mm/dd/yyyy).
+	AppointmentDate string `json:"appointmentdate"`
+	// The time (hh24:mi) for the new appointment slot. Multiple times (either as a comma delimited list or multiple POSTed values) are allowed. 24 hour time.
+	AppointmentTime []string `json:"appointmenttime"`
+	// The appointment type ID to be created. Either this or a reason must be provided.
+	AppointmentTypeID *string `json:"appointmenttypeid"`
+	// The athenaNet department ID.
+	DepartmentID string `json:"departmentid"`
+	// The athenaNet provider ID.
+	ProviderID string `json:"providerid"`
+	// The appointment reason (/patientappointmentreasons) to be created. Either this or a raw appointment type ID must be provided.
+	ReasonID *string `json:"reasonid"`
 }
 
 type CreateAppointmentSlotResult struct {
@@ -27,25 +33,30 @@ func (h *HTTPClient) CreateAppointmentSlot(ctx context.Context, opts *CreateAppo
 	out := CreateAppointmentSlotResult{}
 
 	q := url.Values{}
+
 	if opts != nil {
-		if opts.AppointmentDate != "" {
+		if opts.AppointmentDate == "" {
+			return nil, fmt.Errorf("cannot CreateAppointmentSlot when AppointmentDate is empty [%s]", opts.AppointmentDate)
+		} else {
 			q.Set("appointmentdate", opts.AppointmentDate)
 		}
 
 		if len(opts.AppointmentTime) > 0 {
 			q.Set("appointmenttime", strings.Join(opts.AppointmentTime, ","))
+		} else {
+			return nil, fmt.Errorf("cannot CreateAppointmentSlot without at least one AppointmentTime [%+v]", opts.AppointmentTime)
 		}
 
-		if opts.AppointmentTypeID != nil {
-			q.Set("appointmenttypeid", strconv.Itoa(*opts.AppointmentTypeID))
+		if opts.AppointmentTypeID != nil && *opts.AppointmentTypeID != "" {
+			q.Set("appointmenttypeid", *opts.AppointmentTypeID)
 		}
 
-		q.Set("departmentid", strconv.Itoa(opts.DepartmentID))
+		q.Set("departmentid", opts.DepartmentID)
 
-		q.Set("providerid", strconv.Itoa(opts.ProviderID))
+		q.Set("providerid", opts.ProviderID)
 
 		if opts.ReasonID != nil {
-			q.Set("reasonid", strconv.Itoa(*opts.ReasonID))
+			q.Set("reasonid", *opts.ReasonID)
 		}
 	}
 

--- a/athenahealth/appointment_slots_test.go
+++ b/athenahealth/appointment_slots_test.go
@@ -15,10 +15,10 @@ func TestHTTPClient_CreateAppointmentSlot(t *testing.T) {
 	opts := &CreateAppointmentSlotOptions{
 		AppointmentDate:   "03/22/1945",
 		AppointmentTime:   []string{"21:42", "01:59"},
-		AppointmentTypeID: PtrStr("7"),
+		AppointmentTypeID: ptrStr("7"),
 		DepartmentID:      "27",
 		ProviderID:        "99",
-		ReasonID:          PtrStr("8"),
+		ReasonID:          ptrStr("8"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/appointment_slots_test.go
+++ b/athenahealth/appointment_slots_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -16,10 +15,10 @@ func TestHTTPClient_CreateAppointmentSlot(t *testing.T) {
 	opts := &CreateAppointmentSlotOptions{
 		AppointmentDate:   "03/22/1945",
 		AppointmentTime:   []string{"21:42", "01:59"},
-		AppointmentTypeID: func() *int { a := 7; return &a }(),
-		DepartmentID:      27,
-		ProviderID:        99,
-		ReasonID:          func() *int { a := 8; return &a }(),
+		AppointmentTypeID: func() *string { a := "7"; return &a }(),
+		DepartmentID:      "27",
+		ProviderID:        "99",
+		ReasonID:          func() *string { a := "8"; return &a }(),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
@@ -27,10 +26,10 @@ func TestHTTPClient_CreateAppointmentSlot(t *testing.T) {
 
 		assert.Equal(r.Form.Get("appointmentdate"), opts.AppointmentDate)
 		assert.Equal(r.Form.Get("appointmenttime"), strings.Join(opts.AppointmentTime, ","))
-		assert.Equal(r.Form.Get("appointmenttypeid"), strconv.Itoa(*opts.AppointmentTypeID))
-		assert.Equal(r.Form.Get("departmentid"), strconv.Itoa(opts.DepartmentID))
-		assert.Equal(r.Form.Get("providerid"), strconv.Itoa(opts.ProviderID))
-		assert.Equal(r.Form.Get("reasonid"), strconv.Itoa(*opts.ReasonID))
+		assert.Equal(r.Form.Get("appointmenttypeid"), *opts.AppointmentTypeID)
+		assert.Equal(r.Form.Get("departmentid"), opts.DepartmentID)
+		assert.Equal(r.Form.Get("providerid"), opts.ProviderID)
+		assert.Equal(r.Form.Get("reasonid"), *opts.ReasonID)
 		assert.Equal(r.URL.Path, "/appointments/open")
 		b, _ := os.ReadFile("./resources/CreateAppointmentSlot.json")
 		w.Write(b)

--- a/athenahealth/appointment_slots_test.go
+++ b/athenahealth/appointment_slots_test.go
@@ -15,10 +15,10 @@ func TestHTTPClient_CreateAppointmentSlot(t *testing.T) {
 	opts := &CreateAppointmentSlotOptions{
 		AppointmentDate:   "03/22/1945",
 		AppointmentTime:   []string{"21:42", "01:59"},
-		AppointmentTypeID: func() *string { a := "7"; return &a }(),
+		AppointmentTypeID: PtrStr("7"),
 		DepartmentID:      "27",
 		ProviderID:        "99",
-		ReasonID:          func() *string { a := "8"; return &a }(),
+		ReasonID:          PtrStr("8"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/appointment_types.go
+++ b/athenahealth/appointment_types.go
@@ -7,12 +7,18 @@ import (
 )
 
 type CreateAppointmentTypeOptions struct {
-	Duration         string `json:"duration"`
-	Generic          *bool  `json:"generic"`
-	Name             string `json:"name"`
-	Patient          bool   `json:"patient"`
-	ShortName        string `json:"shortname"`
-	TemplateTypeOnly *bool  `json:"templatetypeonly"`
+	// The expected duration, in minutes, of the appointment type. Note, this value cannot be changed after creation, so please choose carefully.
+	Duration string `json:"duration"`
+	// If set to true, this type serves as a "generic" type, that will match any type when searching. Defaults to false.
+	Generic *bool `json:"generic"`
+	// The name of the appointment type. Maximum length of 30 characters.
+	Name string `json:"name"`
+	// If set to true, this type serves as a "patient" type, meaning that is is a type that can be used for booking patients. If set to false, then it this type will not be used for patient (e.g. "Lunch" or "Vacation"). Non-patient types are mostly used to reserving time for providers to not see patients.
+	Patient bool `json:"patient"`
+	// The short name code of the appointment type. Maximum length of 4 characters. Used for making schedule templates. Note, this value cannot be changed after creation, so please choose carefully.
+	ShortName string `json:"shortname"`
+	// If set to true, this type serves as a "template-only" type, meaning that it can be used for building schedule templates, but cannot be used for booking appointments (i.e. another type must be chosen). Defaults to false.
+	TemplateTypeOnly *bool `json:"templatetypeonly"`
 }
 
 type CreateAppointmentTypeResult struct {

--- a/athenahealth/appointment_types_test.go
+++ b/athenahealth/appointment_types_test.go
@@ -14,11 +14,11 @@ func TestHTTPClient_CreateAppointmentType(t *testing.T) {
 
 	opts := &CreateAppointmentTypeOptions{
 		Duration:         "99",
-		Generic:          func() *bool { a := true; return &a }(),
+		Generic:          PtrBool(true),
 		Name:             "1001",
 		Patient:          true,
 		ShortName:        "11",
-		TemplateTypeOnly: func() *bool { a := false; return &a }(),
+		TemplateTypeOnly: PtrBool(true),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/appointment_types_test.go
+++ b/athenahealth/appointment_types_test.go
@@ -14,11 +14,11 @@ func TestHTTPClient_CreateAppointmentType(t *testing.T) {
 
 	opts := &CreateAppointmentTypeOptions{
 		Duration:         "99",
-		Generic:          PtrBool(true),
+		Generic:          ptrBool(true),
 		Name:             "1001",
 		Patient:          true,
 		ShortName:        "11",
-		TemplateTypeOnly: PtrBool(true),
+		TemplateTypeOnly: ptrBool(true),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/appointments.go
+++ b/athenahealth/appointments.go
@@ -780,7 +780,7 @@ func (h *HTTPClient) RescheduleAppointment(ctx context.Context, apptID string, o
 		}
 
 		if opts.IgnoreSchedulablePermission != nil {
-			form.Set("ignoreschedulablepermission", "true")
+			form.Set("ignoreschedulablepermission", strconv.FormatBool(*opts.IgnoreSchedulablePermission))
 		}
 
 		form.Set("newappointmentid", opts.NewAppointmentID)

--- a/athenahealth/appointments.go
+++ b/athenahealth/appointments.go
@@ -224,10 +224,10 @@ func (h *HTTPClient) ListBookedAppointments(ctx context.Context, opts *ListBooke
 
 type ListChangedAppointmentsOptions struct {
 	DepartmentID               string
-	LeaveUnprocessed           bool
+	LeaveUnprocessed           *bool
 	PatientID                  string
 	ProviderID                 string
-	ShowPatientDetail          bool
+	ShowPatientDetail          *bool
 	ShowProcessedEndDatetime   time.Time
 	ShowProcessedStartDatetime time.Time
 }
@@ -247,20 +247,24 @@ func (h *HTTPClient) ListChangedAppointments(ctx context.Context, opts *ListChan
 	q := url.Values{}
 
 	if opts != nil {
-		if len(opts.ProviderID) > 0 {
-			q.Add("providerid", opts.ProviderID)
-		}
-
 		if len(opts.DepartmentID) > 0 {
 			q.Add("departmentid", opts.DepartmentID)
+		}
+
+		if opts.LeaveUnprocessed != nil {
+			q.Add("leaveunprocessed", strconv.FormatBool(*opts.LeaveUnprocessed))
 		}
 
 		if len(opts.PatientID) > 0 {
 			q.Add("patientid", opts.PatientID)
 		}
 
-		if opts.ShowPatientDetail {
-			q.Add("showpatientdetail", strconv.FormatBool(opts.ShowPatientDetail))
+		if len(opts.ProviderID) > 0 {
+			q.Add("providerid", opts.ProviderID)
+		}
+
+		if opts.ShowPatientDetail != nil {
+			q.Add("showpatientdetail", strconv.FormatBool(*opts.ShowPatientDetail))
 		}
 
 		if !opts.ShowProcessedEndDatetime.IsZero() {
@@ -271,9 +275,6 @@ func (h *HTTPClient) ListChangedAppointments(ctx context.Context, opts *ListChan
 			q.Add("showprocessedstartdatetime", opts.ShowProcessedStartDatetime.Format("01/02/2006 15:04:05"))
 		}
 
-		if opts.LeaveUnprocessed {
-			q.Add("leaveunprocessed", strconv.FormatBool(opts.LeaveUnprocessed))
-		}
 	}
 
 	_, err := h.Get(ctx, "/appointments/changed", q, out)
@@ -286,7 +287,7 @@ func (h *HTTPClient) ListChangedAppointments(ctx context.Context, opts *ListChan
 
 type CreateAppointmentNoteOptions struct {
 	AppointmentID     string
-	DisplayOnSchedule bool
+	DisplayOnSchedule *bool
 	NoteText          string
 }
 
@@ -303,8 +304,8 @@ func (h *HTTPClient) CreateAppointmentNote(ctx context.Context, appointmentID st
 			form.Add("appointmentid", opts.AppointmentID)
 		}
 
-		if opts.DisplayOnSchedule {
-			form.Add("displayonschedule", strconv.FormatBool(opts.DisplayOnSchedule))
+		if opts.DisplayOnSchedule != nil {
+			form.Add("displayonschedule", strconv.FormatBool(*opts.DisplayOnSchedule))
 		}
 
 		if len(opts.NoteText) > 0 {
@@ -330,7 +331,7 @@ type AppointmentNote struct {
 
 type ListAppointmentNotesOptions struct {
 	AppointmentID string
-	ShowDeleted   bool
+	ShowDeleted   *bool
 }
 
 type listAppointmentNotesResponse struct {
@@ -352,8 +353,8 @@ func (h *HTTPClient) ListAppointmentNotes(ctx context.Context, appointmentID str
 			q.Add("appointmentid", opts.AppointmentID)
 		}
 
-		if opts.ShowDeleted {
-			q.Add("showdeleted", strconv.FormatBool(opts.ShowDeleted))
+		if opts.ShowDeleted != nil {
+			q.Add("showdeleted", strconv.FormatBool(*opts.ShowDeleted))
 		}
 	}
 
@@ -367,7 +368,7 @@ func (h *HTTPClient) ListAppointmentNotes(ctx context.Context, appointmentID str
 
 type UpdateAppointmentNoteOptions struct {
 	AppointmentID     string
-	DisplayOnSchedule bool
+	DisplayOnSchedule *bool
 	NoteID            string
 	NoteText          string
 }
@@ -385,8 +386,8 @@ func (h *HTTPClient) UpdateAppointmentNote(ctx context.Context, appointmentID, n
 			form.Add("appointmentid", opts.AppointmentID)
 		}
 
-		if opts.DisplayOnSchedule {
-			form.Add("displayonschedule", strconv.FormatBool(opts.DisplayOnSchedule))
+		if opts.DisplayOnSchedule != nil {
+			form.Add("displayonschedule", strconv.FormatBool(*opts.DisplayOnSchedule))
 		}
 
 		if len(opts.NoteID) > 0 {

--- a/athenahealth/appointments.go
+++ b/athenahealth/appointments.go
@@ -511,8 +511,8 @@ func (h *HTTPClient) ListOpenAppointmentSlots(ctx context.Context, opts *ListOpe
 			q.Add("appointmenttypeid", *opts.AppointmentTypeID)
 		}
 
-		if opts.BypassScheduleTimeChecks != nil && *opts.BypassScheduleTimeChecks {
-			q.Add("bypassscheduletimechecks", "true")
+		if opts.BypassScheduleTimeChecks != nil {
+			q.Add("bypassscheduletimechecks", strconv.FormatBool(*opts.BypassScheduleTimeChecks))
 		}
 
 		if len(opts.DepartmentIDs) > 0 {
@@ -523,8 +523,8 @@ func (h *HTTPClient) ListOpenAppointmentSlots(ctx context.Context, opts *ListOpe
 			q.Add("enddate", opts.EndDate.Format("01/02/2006"))
 		}
 
-		if opts.IgnoreSchedulablePermission != nil && *opts.IgnoreSchedulablePermission {
-			q.Add("ignoreschedulablepermission", "true")
+		if opts.IgnoreSchedulablePermission != nil {
+			q.Add("ignoreschedulablepermission", strconv.FormatBool(*opts.IgnoreSchedulablePermission))
 		}
 
 		if len(opts.ProviderIDs) > 0 {
@@ -539,8 +539,8 @@ func (h *HTTPClient) ListOpenAppointmentSlots(ctx context.Context, opts *ListOpe
 			q.Add("startdate", opts.StartDate.Format("01/02/2006"))
 		}
 
-		if opts.ShowFrozenSlots != nil && *opts.ShowFrozenSlots {
-			q.Add("showfrozenslots", "true")
+		if opts.ShowFrozenSlots != nil {
+			q.Add("showfrozenslots", strconv.FormatBool(*opts.ShowFrozenSlots))
 		}
 
 		if opts.Limit > 0 {
@@ -607,24 +607,24 @@ func (h *HTTPClient) BookAppointment(ctx context.Context, apptID string, opts *B
 			form.Add("departmentid", *opts.DepartmentID)
 		}
 
-		if opts.DoNotSendConfirmationEmail != nil && *opts.DoNotSendConfirmationEmail {
-			form.Add("donotsendconfirmationemail", "true")
+		if opts.DoNotSendConfirmationEmail != nil {
+			form.Add("donotsendconfirmationemail", strconv.FormatBool(*opts.DoNotSendConfirmationEmail))
 		}
 
-		if opts.IgnoreSchedulablePermission != nil && *opts.IgnoreSchedulablePermission {
-			form.Add("ignoreschedulablepermission", "true")
+		if opts.IgnoreSchedulablePermission != nil {
+			form.Add("ignoreschedulablepermission", strconv.FormatBool(*opts.IgnoreSchedulablePermission))
 		}
 
-		if opts.NoPatientCase != nil && *opts.NoPatientCase {
-			form.Add("nopatientcase", "true")
+		if opts.NoPatientCase != nil {
+			form.Add("nopatientcase", strconv.FormatBool(*opts.NoPatientCase))
 		}
 
 		if opts.ReasonID != nil && *opts.ReasonID != "" {
 			form.Add("reasonid", *opts.ReasonID)
 		}
 
-		if opts.Urgent != nil && *opts.Urgent {
-			form.Add("urgent", "true")
+		if opts.Urgent != nil {
+			form.Add("urgent", strconv.FormatBool(*opts.Urgent))
 		}
 	}
 
@@ -785,7 +785,7 @@ func (h *HTTPClient) RescheduleAppointment(ctx context.Context, apptID string, o
 			q.Set("appointmentcancelreasonid", *opts.AppointmentCancelReasonID)
 		}
 
-		if opts.IgnoreSchedulablePermission != nil && *opts.IgnoreSchedulablePermission {
+		if opts.IgnoreSchedulablePermission != nil {
 			q.Set("ignoreschedulablepermission", "true")
 		}
 

--- a/athenahealth/appointments.go
+++ b/athenahealth/appointments.go
@@ -33,7 +33,7 @@ type Appointment struct {
 //
 // https://docs.athenahealth.com/api/api-ref/appointment#Get-appointment-details
 func (h *HTTPClient) GetAppointment(ctx context.Context, id string) (*Appointment, error) {
-	out := []*Appointment{}
+	var out []*Appointment
 
 	_, err := h.Get(ctx, fmt.Sprintf("/appointments/%s", id), nil, &out)
 	if err != nil {
@@ -296,11 +296,9 @@ type CreateAppointmentNoteOptions struct {
 //
 // https://docs.athenahealth.com/api/api-ref/appointment-notes#Create-appointment-note
 func (h *HTTPClient) CreateAppointmentNote(ctx context.Context, appointmentID string, opts *CreateAppointmentNoteOptions) error {
-	var form url.Values
+	form := url.Values{}
 
 	if opts != nil {
-		form = url.Values{}
-
 		if len(opts.AppointmentID) > 0 {
 			form.Add("appointmentid", opts.AppointmentID)
 		}
@@ -380,11 +378,9 @@ type UpdateAppointmentNoteOptions struct {
 //
 // https://docs.athenahealth.com/api/api-ref/appointment-notes#Update-appointment-note
 func (h *HTTPClient) UpdateAppointmentNote(ctx context.Context, appointmentID, noteID string, opts *UpdateAppointmentNoteOptions) error {
-	var form url.Values
+	form := url.Values{}
 
 	if opts != nil {
-		form = url.Values{}
-
 		if len(opts.AppointmentID) > 0 {
 			form.Add("appointmentid", opts.AppointmentID)
 		}
@@ -421,11 +417,9 @@ type DeleteAppointmentNoteOptions struct {
 //
 // https://docs.athenahealth.com/api/api-ref/appointment-notes#Delete-appointment-note
 func (h *HTTPClient) DeleteAppointmentNote(ctx context.Context, appointmentID, noteID string, opts *DeleteAppointmentNoteOptions) error {
-	var form url.Values
+	form := url.Values{}
 
 	if opts != nil {
-		form = url.Values{}
-
 		if len(opts.AppointmentID) > 0 {
 			form.Add("appointmentid", opts.AppointmentID)
 		}
@@ -592,8 +586,6 @@ func (h *HTTPClient) BookAppointment(ctx context.Context, apptID string, opts *B
 
 	form := url.Values{}
 
-	form.Add("patientid", opts.PatientID)
-
 	if opts != nil {
 		if opts.AppointmentTypeID != nil && *opts.AppointmentTypeID != "" {
 			form.Add("appointmenttypeid", *opts.AppointmentTypeID)
@@ -618,6 +610,8 @@ func (h *HTTPClient) BookAppointment(ctx context.Context, apptID string, opts *B
 		if opts.NoPatientCase != nil {
 			form.Add("nopatientcase", strconv.FormatBool(*opts.NoPatientCase))
 		}
+
+		form.Add("patientid", opts.PatientID)
 
 		if opts.ReasonID != nil && *opts.ReasonID != "" {
 			form.Add("reasonid", *opts.ReasonID)
@@ -778,35 +772,35 @@ type RescheduleAppointmentOptions struct {
 func (h *HTTPClient) RescheduleAppointment(ctx context.Context, apptID string, opts *RescheduleAppointmentOptions) (*RescheduleAppointmentResult, error) {
 	var out []*RescheduleAppointmentResult
 
-	q := url.Values{}
+	form := url.Values{}
 
 	if opts != nil {
 		if opts.AppointmentCancelReasonID != nil && *opts.AppointmentCancelReasonID != "" {
-			q.Set("appointmentcancelreasonid", *opts.AppointmentCancelReasonID)
+			form.Set("appointmentcancelreasonid", *opts.AppointmentCancelReasonID)
 		}
 
 		if opts.IgnoreSchedulablePermission != nil {
-			q.Set("ignoreschedulablepermission", "true")
+			form.Set("ignoreschedulablepermission", "true")
 		}
 
-		q.Set("newappointmentid", opts.NewAppointmentID)
+		form.Set("newappointmentid", opts.NewAppointmentID)
 
 		if opts.NoPatientCase != nil {
-			q.Set("nopatientcase", strconv.FormatBool(*opts.NoPatientCase))
+			form.Set("nopatientcase", strconv.FormatBool(*opts.NoPatientCase))
 		}
 
-		q.Set("patientid", opts.PatientID)
+		form.Set("patientid", opts.PatientID)
 
 		if opts.ReasonID != nil && *opts.ReasonID != "" {
-			q.Set("reasonid", *opts.ReasonID)
+			form.Set("reasonid", *opts.ReasonID)
 		}
 
 		if opts.RescheduleReason != nil && *opts.RescheduleReason != "" {
-			q.Set("reschedulereason", *opts.RescheduleReason)
+			form.Set("reschedulereason", *opts.RescheduleReason)
 		}
 	}
 
-	_, err := h.PutForm(ctx, fmt.Sprintf("/appointments/%s/reschedule", apptID), q, &out)
+	_, err := h.PutForm(ctx, fmt.Sprintf("/appointments/%s/reschedule", apptID), form, &out)
 
 	if err != nil {
 		return nil, err

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -224,7 +224,7 @@ func TestHTTPClient_ListOpenAppointmentSlots(t *testing.T) {
 		BypassScheduleTimeChecks:    PtrBool(true),
 		DepartmentIDs:               []string{"1"},
 		EndDate:                     &endDate,
-		IgnoreSchedulablePermission: PtrBool(true),
+		IgnoreSchedulablePermission: PtrBool(false),
 		ProviderIDs:                 []string{"4", "5"},
 		ReasonIDs:                   []string{"2", "3"},
 		ShowFrozenSlots:             PtrBool(true),
@@ -271,11 +271,11 @@ func TestHTTPClient_BookAppointment(t *testing.T) {
 		BookingNote:                 PtrStr("Hello World!"),
 		DepartmentID:                PtrStr("4"),
 		DoNotSendConfirmationEmail:  PtrBool(true),
-		IgnoreSchedulablePermission: PtrBool(true),
+		IgnoreSchedulablePermission: PtrBool(false),
 		NoPatientCase:               PtrBool(true),
 		PatientID:                   "1",
 		ReasonID:                    PtrStr("5"),
-		Urgent:                      PtrBool(true),
+		Urgent:                      PtrBool(false),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
@@ -379,7 +379,7 @@ func TestHTTPClient_RescheduleAppointment(t *testing.T) {
 		AppointmentCancelReasonID:   PtrStr("2"),
 		IgnoreSchedulablePermission: PtrBool(true),
 		NewAppointmentID:            "123",
-		NoPatientCase:               PtrBool(true),
+		NoPatientCase:               PtrBool(false),
 		PatientID:                   "456",
 		ReasonID:                    PtrStr("3"),
 		RescheduleReason:            PtrStr("other commitments"),

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -225,24 +225,26 @@ func TestHTTPClient_ListOpenAppointmentSlots(t *testing.T) {
 		DepartmentIDs:               []string{"1"},
 		EndDate:                     &endDate,
 		IgnoreSchedulablePermission: PtrBool(true),
-		Limit:                       6,
-		Offset:                      7,
 		ProviderIDs:                 []string{"4", "5"},
 		ReasonIDs:                   []string{"2", "3"},
 		ShowFrozenSlots:             PtrBool(true),
 		StartDate:                   &startDate,
+
+		Limit:  6,
+		Offset: 7,
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(*opts.AppointmentTypeID, r.URL.Query().Get("appointmenttypeid"))
-		assert.Equal(strings.Join(opts.ReasonIDs, ","), r.URL.Query().Get("reasonid"))
-		assert.Equal(strings.Join(opts.DepartmentIDs, ","), r.URL.Query().Get("departmentid"))
 		assert.Equal(strconv.FormatBool(*opts.BypassScheduleTimeChecks), r.URL.Query().Get("bypassscheduletimechecks"))
+		assert.Equal(strings.Join(opts.DepartmentIDs, ","), r.URL.Query().Get("departmentid"))
 		assert.Equal((*opts.EndDate).Format("01/02/2006"), r.URL.Query().Get("enddate"))
-		assert.Equal(strings.Join(opts.ProviderIDs, ","), r.URL.Query().Get("providerid"))
-		assert.Equal((*opts.StartDate).Format("01/02/2006"), r.URL.Query().Get("startdate"))
 		assert.Equal(strconv.FormatBool(*opts.IgnoreSchedulablePermission), r.URL.Query().Get("ignoreschedulablepermission"))
+		assert.Equal(strings.Join(opts.ProviderIDs, ","), r.URL.Query().Get("providerid"))
+		assert.Equal(strings.Join(opts.ReasonIDs, ","), r.URL.Query().Get("reasonid"))
 		assert.Equal(strconv.FormatBool(*opts.ShowFrozenSlots), r.URL.Query().Get("showfrozenslots"))
+		assert.Equal((*opts.StartDate).Format("01/02/2006"), r.URL.Query().Get("startdate"))
+
 		assert.Equal(strconv.Itoa(opts.Limit), r.URL.Query().Get("limit"))
 		assert.Equal(strconv.Itoa(opts.Offset), r.URL.Query().Get("offset"))
 
@@ -282,12 +284,12 @@ func TestHTTPClient_BookAppointment(t *testing.T) {
 		assert.Equal(r.Form.Get("appointmenttypeid"), *opts.AppointmentTypeID)
 		assert.Equal(r.Form.Get("bookingnote"), *opts.BookingNote)
 		assert.Equal(r.Form.Get("departmentid"), *opts.DepartmentID)
-		assert.Equal(r.Form.Get("donotsendconfirmationemail"), "true")
-		assert.Equal(r.Form.Get("ignoreschedulablepermission"), "true")
-		assert.Equal(r.Form.Get("nopatientcase"), "true")
+		assert.Equal(r.Form.Get("donotsendconfirmationemail"), strconv.FormatBool(*opts.DoNotSendConfirmationEmail))
+		assert.Equal(r.Form.Get("ignoreschedulablepermission"), strconv.FormatBool(*opts.IgnoreSchedulablePermission))
+		assert.Equal(r.Form.Get("nopatientcase"), strconv.FormatBool(*opts.NoPatientCase))
 		assert.Equal(r.Form.Get("patientid"), "1")
 		assert.Equal(r.Form.Get("reasonid"), "5")
-		assert.Equal(r.Form.Get("urgent"), "true")
+		assert.Equal(r.Form.Get("urgent"), strconv.FormatBool(*opts.Urgent))
 
 		b, _ := os.ReadFile("./resources/BookAppointment.json")
 		w.Write(b)
@@ -387,9 +389,9 @@ func TestHTTPClient_RescheduleAppointment(t *testing.T) {
 		assert.NoError(r.ParseForm())
 
 		assert.Equal(r.Form.Get("appointmentcancelreasonid"), *opts.AppointmentCancelReasonID)
-		assert.Equal(r.Form.Get("ignoreschedulablepermission"), "true")
+		assert.Equal(r.Form.Get("ignoreschedulablepermission"), strconv.FormatBool(*opts.IgnoreSchedulablePermission))
 		assert.Equal(r.Form.Get("newappointmentid"), opts.NewAppointmentID)
-		assert.Equal(r.Form.Get("nopatientcase"), "true")
+		assert.Equal(r.Form.Get("nopatientcase"), strconv.FormatBool(*opts.NoPatientCase))
 		assert.Equal(r.Form.Get("patientid"), opts.PatientID)
 		assert.Equal(r.Form.Get("reasonid"), *opts.ReasonID)
 		assert.Equal(r.Form.Get("reschedulereason"), *opts.RescheduleReason)

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -65,7 +65,7 @@ func TestHTTPClient_ListBookedAppointments(t *testing.T) {
 	defer ts.Close()
 
 	opts := &ListBookedAppointmentsOptions{
-		ProviderID:        PtrStr("1"),
+		ProviderID:        ptrStr("1"),
 		StartDate:         time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC),
 		EndDate:           time.Date(2020, 6, 3, 0, 0, 0, 0, time.UTC),
 		AppointmentStatus: func() *AppointmentStatus { a := AppointmentStatusCancelled; return &a }(),
@@ -220,14 +220,14 @@ func TestHTTPClient_ListOpenAppointmentSlots(t *testing.T) {
 	startDate := time.Now()
 
 	opts := &ListOpenAppointmentSlotOptions{
-		AppointmentTypeID:           PtrStr("1"),
-		BypassScheduleTimeChecks:    PtrBool(true),
+		AppointmentTypeID:           ptrStr("1"),
+		BypassScheduleTimeChecks:    ptrBool(true),
 		DepartmentIDs:               []string{"1"},
 		EndDate:                     &endDate,
-		IgnoreSchedulablePermission: PtrBool(false),
+		IgnoreSchedulablePermission: ptrBool(false),
 		ProviderIDs:                 []string{"4", "5"},
 		ReasonIDs:                   []string{"2", "3"},
-		ShowFrozenSlots:             PtrBool(true),
+		ShowFrozenSlots:             ptrBool(true),
 		StartDate:                   &startDate,
 
 		Limit:  6,
@@ -267,15 +267,15 @@ func TestHTTPClient_BookAppointment(t *testing.T) {
 	apptID := "2"
 
 	opts := &BookAppointmentOptions{
-		AppointmentTypeID:           PtrStr("3"),
-		BookingNote:                 PtrStr("Hello World!"),
-		DepartmentID:                PtrStr("4"),
-		DoNotSendConfirmationEmail:  PtrBool(true),
-		IgnoreSchedulablePermission: PtrBool(false),
-		NoPatientCase:               PtrBool(true),
+		AppointmentTypeID:           ptrStr("3"),
+		BookingNote:                 ptrStr("Hello World!"),
+		DepartmentID:                ptrStr("4"),
+		DoNotSendConfirmationEmail:  ptrBool(true),
+		IgnoreSchedulablePermission: ptrBool(false),
+		NoPatientCase:               ptrBool(true),
 		PatientID:                   "1",
-		ReasonID:                    PtrStr("5"),
-		Urgent:                      PtrBool(false),
+		ReasonID:                    ptrStr("5"),
+		Urgent:                      ptrBool(false),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
@@ -309,10 +309,10 @@ func TestHTTPClient_UpdateBookedAppointment_IntResponse(t *testing.T) {
 	apptID := "1230322"
 
 	opts := &UpdateBookedAppointmentOptions{
-		AppointmentTypeID:     PtrStr("*opts.AppointmentTypeID"),
-		DepartmentID:          PtrStr("*opts.DepartmentID"),
-		ProviderID:            PtrStr("*opts.ProviderID"),
-		SupervisingProviderID: PtrStr("*opts.SupervisingProviderID"),
+		AppointmentTypeID:     ptrStr("*opts.AppointmentTypeID"),
+		DepartmentID:          ptrStr("*opts.DepartmentID"),
+		ProviderID:            ptrStr("*opts.ProviderID"),
+		SupervisingProviderID: ptrStr("*opts.SupervisingProviderID"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
@@ -342,10 +342,10 @@ func TestHTTPClient_UpdateBookedAppointment_StringResponse(t *testing.T) {
 	apptID := "1230322"
 
 	opts := &UpdateBookedAppointmentOptions{
-		AppointmentTypeID:     PtrStr("opts.AppointmentTypeID"),
-		DepartmentID:          PtrStr("opts.DepartmentID"),
-		ProviderID:            PtrStr("opts.ProviderID"),
-		SupervisingProviderID: PtrStr("opts.SupervisingProviderID"),
+		AppointmentTypeID:     ptrStr("opts.AppointmentTypeID"),
+		DepartmentID:          ptrStr("opts.DepartmentID"),
+		ProviderID:            ptrStr("opts.ProviderID"),
+		SupervisingProviderID: ptrStr("opts.SupervisingProviderID"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
@@ -376,13 +376,13 @@ func TestHTTPClient_RescheduleAppointment(t *testing.T) {
 	apptID := "998877"
 
 	opts := &RescheduleAppointmentOptions{
-		AppointmentCancelReasonID:   PtrStr("2"),
-		IgnoreSchedulablePermission: PtrBool(true),
+		AppointmentCancelReasonID:   ptrStr("2"),
+		IgnoreSchedulablePermission: ptrBool(true),
 		NewAppointmentID:            "123",
-		NoPatientCase:               PtrBool(false),
+		NoPatientCase:               ptrBool(false),
 		PatientID:                   "456",
-		ReasonID:                    PtrStr("3"),
-		RescheduleReason:            PtrStr("other commitments"),
+		ReasonID:                    ptrStr("3"),
+		RescheduleReason:            ptrStr("other commitments"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/appointments_test.go
+++ b/athenahealth/appointments_test.go
@@ -65,7 +65,7 @@ func TestHTTPClient_ListBookedAppointments(t *testing.T) {
 	defer ts.Close()
 
 	opts := &ListBookedAppointmentsOptions{
-		ProviderID:        func() *string { a := "1"; return &a }(),
+		ProviderID:        PtrStr("1"),
 		StartDate:         time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC),
 		EndDate:           time.Date(2020, 6, 3, 0, 0, 0, 0, time.UTC),
 		AppointmentStatus: func() *AppointmentStatus { a := AppointmentStatusCancelled; return &a }(),
@@ -307,10 +307,10 @@ func TestHTTPClient_UpdateBookedAppointment_IntResponse(t *testing.T) {
 	apptID := "1230322"
 
 	opts := &UpdateBookedAppointmentOptions{
-		AppointmentTypeID:     func() *string { a := "opts.AppointmentTypeID"; return &a }(),
-		DepartmentID:          func() *string { a := "opts.DepartmentID"; return &a }(),
-		ProviderID:            func() *string { a := "opts.ProviderID"; return &a }(),
-		SupervisingProviderID: func() *string { a := "opts.SupervisingProviderID"; return &a }(),
+		AppointmentTypeID:     PtrStr("*opts.AppointmentTypeID"),
+		DepartmentID:          PtrStr("*opts.DepartmentID"),
+		ProviderID:            PtrStr("*opts.ProviderID"),
+		SupervisingProviderID: PtrStr("*opts.SupervisingProviderID"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {
@@ -340,10 +340,10 @@ func TestHTTPClient_UpdateBookedAppointment_StringResponse(t *testing.T) {
 	apptID := "1230322"
 
 	opts := &UpdateBookedAppointmentOptions{
-		AppointmentTypeID:     func() *string { a := "opts.AppointmentTypeID"; return &a }(),
-		DepartmentID:          func() *string { a := "opts.DepartmentID"; return &a }(),
-		ProviderID:            func() *string { a := "opts.ProviderID"; return &a }(),
-		SupervisingProviderID: func() *string { a := "opts.SupervisingProviderID"; return &a }(),
+		AppointmentTypeID:     PtrStr("opts.AppointmentTypeID"),
+		DepartmentID:          PtrStr("opts.DepartmentID"),
+		ProviderID:            PtrStr("opts.ProviderID"),
+		SupervisingProviderID: PtrStr("opts.SupervisingProviderID"),
 	}
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	ListBookedAppointments(context.Context, *ListBookedAppointmentsOptions) (*ListBookedAppointmentsResult, error)
 	ListChangedAppointments(context.Context, *ListChangedAppointmentsOptions) ([]*BookedAppointment, error)
 	ListOpenAppointmentSlots(ctx context.Context, departmentID int, opts *ListOpenAppointmentSlotOptions) (*ListOpenAppointmentSlotsResult, error)
-	BookAppointment(ctx context.Context, patientID, apptID string, opts *BookAppointmentOptions) (*BookedAppointment, error)
+	BookAppointment(ctx context.Context, apptID string, opts *BookAppointmentOptions) (*BookedAppointment, error)
 	UpdateBookedAppointment(ctx context.Context, apptID string, opts *UpdateBookedAppointmentOptions) error
 	RescheduleAppointment(ctx context.Context, apptID int, opts *RescheduleAppointmentOptions) (*RescheduleAppointmentResult, error)
 

--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -24,10 +24,10 @@ type Client interface {
 	GetAppointment(ctx context.Context, appointmentID string) (*Appointment, error)
 	ListBookedAppointments(context.Context, *ListBookedAppointmentsOptions) (*ListBookedAppointmentsResult, error)
 	ListChangedAppointments(context.Context, *ListChangedAppointmentsOptions) ([]*BookedAppointment, error)
-	ListOpenAppointmentSlots(ctx context.Context, departmentID int, opts *ListOpenAppointmentSlotOptions) (*ListOpenAppointmentSlotsResult, error)
+	ListOpenAppointmentSlots(ctx context.Context, opts *ListOpenAppointmentSlotOptions) (*ListOpenAppointmentSlotsResult, error)
 	BookAppointment(ctx context.Context, apptID string, opts *BookAppointmentOptions) (*BookedAppointment, error)
 	UpdateBookedAppointment(ctx context.Context, apptID string, opts *UpdateBookedAppointmentOptions) error
-	RescheduleAppointment(ctx context.Context, apptID int, opts *RescheduleAppointmentOptions) (*RescheduleAppointmentResult, error)
+	RescheduleAppointment(ctx context.Context, apptID string, opts *RescheduleAppointmentOptions) (*RescheduleAppointmentResult, error)
 
 	AppointmentCancelCheckIn(ctx context.Context, apptID string) error
 	AppointmentCheckIn(ctx context.Context, apptID string) error

--- a/athenahealth/types.go
+++ b/athenahealth/types.go
@@ -6,13 +6,13 @@ import (
 	"strconv"
 )
 
-// PtrStr mimics aws.String which helps shortcut getting a pointer to a string
-func PtrStr(input string) *string {
+// ptrStr mimics aws.String which helps shortcut getting a pointer to a string
+func ptrStr(input string) *string {
 	return &input
 }
 
-// PtrBool mimics aws.Bool which helps shortcut getting a pointer to a bool
-func PtrBool(input bool) *bool {
+// ptrBool mimics aws.Bool which helps shortcut getting a pointer to a bool
+func ptrBool(input bool) *bool {
 	return &input
 }
 

--- a/athenahealth/types.go
+++ b/athenahealth/types.go
@@ -6,6 +6,16 @@ import (
 	"strconv"
 )
 
+// PtrStr mimics aws.String which helps shortcut getting a pointer to a string
+func PtrStr(input string) *string {
+	return &input
+}
+
+// PtrBool mimics aws.Bool which helps shortcut getting a pointer to a bool
+func PtrBool(input bool) *bool {
+	return &input
+}
+
 type NumberString string
 
 func (n *NumberString) UnmarshalJSON(data []byte) error {

--- a/athenahealth/types.go
+++ b/athenahealth/types.go
@@ -7,12 +7,12 @@ import (
 )
 
 // ptrStr mimics aws.String which helps shortcut getting a pointer to a string
-func ptrStr(input string) *string {
+func ptrStr(input string) *string { // nolint
 	return &input
 }
 
 // ptrBool mimics aws.Bool which helps shortcut getting a pointer to a bool
-func ptrBool(input bool) *bool {
+func ptrBool(input bool) *bool { // nolint
 	return &input
 }
 


### PR DESCRIPTION
## Make Appointment Endpoints consistent

Endpoints across the appointment files are inconsistent for multiple reasons. This PR aims to bring them inline:

* All optional fields are now pointers
* Only path parameters are allowed as function parameters
* PtrStr and PtrBool cleaned up a lot of anonymous function declarations
* Add more athena comments
* More checking for non-optional parameters
* All ID fields are now strings
* All url.Values{} instances are called form except for http GETs which are called q
* All booleans are now pointers to allow differentiating between never set and explicitly set. There are multiple endpoints that can take true or false as a valid value and only allowing true values to go through limits functionality

## Breaking Changes

No intentional breaking changes :sweat_smile: 