### PR TITLE
Fix bodyLength always 0

### DIFF
--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -183,6 +183,12 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		requestBodyLength = srBody.size
 	}
 
+	h.logger.Info().
+		Str("method", method).
+		Str("url", reqURL).
+		Str("xRequestId", xRequestID).
+		Msg("athenahealth API request")
+
 	requestStart := time.Now()
 
 	res, err := h.httpClient.Do(req)
@@ -190,14 +196,6 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		return res, err
 	}
 	defer res.Body.Close()
-
-	h.logger.Info().
-		Str("method", method).
-		Str("url", reqURL).
-		Int64("bodyLength", requestBodyLength).
-		Int64("bodyContentLength", req.ContentLength).
-		Str("xRequestId", xRequestID).
-		Msg("athenahealth API request")
 
 	requestDuration := time.Since(requestStart)
 
@@ -232,7 +230,9 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		Str("method", method).
 		Str("url", reqURL).
 		Int("statusCode", res.StatusCode).
-		Int("bodyLength", len(resBody)).
+		Int("responseBodyLength", len(resBody)).
+		Int64("requestBodyLength", requestBodyLength).
+		Int64("requestContentLength", req.ContentLength).
 		Str("xRequestId", xRequestID).
 		Str("duration", requestDuration.String()).
 		Msg("athenahealth API response")

--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -160,6 +160,9 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 
 	h.requestLock.Unlock()
 
+	if body != nil {
+		body = newSizeRecordingReader(body)
+	}
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
 	if err != nil {
 		return nil, err
@@ -175,10 +178,15 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 	req.Header.Add("User-Agent", userAgent)
 	req.Header.Set(XRequestIDHeaderKey, xRequestID)
 
+	var requestBodyLength int64
+	if srBody, ok := body.(*sizeRecordingReader); ok {
+		requestBodyLength = srBody.size
+	}
+
 	h.logger.Info().
 		Str("method", method).
 		Str("url", reqURL).
-		Int64("bodyLength", req.ContentLength).
+		Int64("bodyLength", requestBodyLength).
 		Str("xRequestId", xRequestID).
 		Msg("athenahealth API request")
 
@@ -255,6 +263,24 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 	}
 
 	return res, nil
+}
+
+type sizeRecordingReader struct {
+	r    io.Reader
+	size int64
+}
+
+func newSizeRecordingReader(r io.Reader) *sizeRecordingReader {
+	return &sizeRecordingReader{
+		r:    r,
+		size: 0,
+	}
+}
+
+func (srr *sizeRecordingReader) Read(p []byte) (int, error) {
+	n, err := srr.r.Read(p)
+	srr.size += int64(n)
+	return n, err
 }
 
 func (h *HTTPClient) WithLogger(logger *zerolog.Logger) *HTTPClient {

--- a/athenahealth/httpclient.go
+++ b/athenahealth/httpclient.go
@@ -183,13 +183,6 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		requestBodyLength = srBody.size
 	}
 
-	h.logger.Info().
-		Str("method", method).
-		Str("url", reqURL).
-		Int64("bodyLength", requestBodyLength).
-		Str("xRequestId", xRequestID).
-		Msg("athenahealth API request")
-
 	requestStart := time.Now()
 
 	res, err := h.httpClient.Do(req)
@@ -197,6 +190,14 @@ func (h *HTTPClient) request(ctx context.Context, method, path string, body io.R
 		return res, err
 	}
 	defer res.Body.Close()
+
+	h.logger.Info().
+		Str("method", method).
+		Str("url", reqURL).
+		Int64("bodyLength", requestBodyLength).
+		Int64("bodyContentLength", req.ContentLength).
+		Str("xRequestId", xRequestID).
+		Msg("athenahealth API request")
 
 	requestDuration := time.Since(requestStart)
 


### PR DESCRIPTION
## Fix bodyLength always 0

The previous approach using a `SizeRecordingReader` does not work because by the time we log, the request has not been read, so it's alwasy 0

## Breaking Changes

none, updates logging

@dillonstreator open to a way of keeping that reader, but I think just moving the log after the line with `.Do()` would log the response instead :thinking: I've used `req.ContentLength` before and it works as expected.
