### PR TITLE
lab result observed at

### DIFF
--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -30,12 +30,12 @@ type LabResult struct {
 }
 
 type ListLabResultsOptions struct {
-	StartDate           *time.Time `json:"startdate"`
-	LabResultStatus     *string    `json:"labresultstatus"`
-	ShowHidden          *bool      `json:"showhidden"`
-	ShowAbnormalDetails *bool      `json:"showabnormaldetails"`
-	EndDate             *time.Time `json:"enddate"`
-	HideDuplicate       *bool      `json:"hideduplicate"`
+	StartDate           *time.Time
+	LabResultStatus     *string
+	ShowHidden          *bool
+	ShowAbnormalDetails *bool
+	EndDate             *time.Time
+	HideDuplicate       *bool
 
 	Pagination *PaginationOptions
 }
@@ -130,18 +130,19 @@ const (
 
 type AddLabResultDocumentOptions struct {
 	// AttachmentContents must be Base64 encoded
-	AttachmentContents io.Reader               `json:"attachmentcontents"`
-	AttachmentType     LabResultAttachmentType `json:"attachmenttype"`
-	InternalNote       *string                 `json:"internalnote"`
-	NoteToPatient      *string                 `json:"notetopatient"`
-	ObservationDate    *time.Time              `json:"observationdate"`
-	OriginalFilename   *string                 `json:"originalfilename"`
+	AttachmentContents io.Reader
+	AttachmentType     LabResultAttachmentType
+	InternalNote       *string
+	NoteToPatient      *string
+	// Sets both observationdate and observationtime if not nil
+	ObservedAt       *time.Time
+	OriginalFilename *string
 	// 1 = high, 2 = normal
-	Priority    *string `json:"priority"`
-	ResultNotes *string `json:"resultnotes"`
+	Priority    *string
+	ResultNotes *string
 	// Final, Partial, Pending, Preliminary, Corrected, Cancelled
-	ResultStatus *string `json:"resultstatus"`
-	TieToOrderID *int    `json:"tietoorderid"`
+	ResultStatus *string
+	TieToOrderID *int
 }
 
 type addLabResultDocumentResponse struct {
@@ -184,8 +185,9 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 		if opts.NoteToPatient != nil {
 			form.AddString("notetopatient", string(*opts.NoteToPatient))
 		}
-		if opts.ObservationDate != nil {
-			form.AddString("observationdate", opts.ObservationDate.Format("01/02/2006"))
+		if opts.ObservedAt != nil {
+			form.AddString("observationdate", opts.ObservedAt.Format("01/02/2006"))
+			form.AddString("observationtime", opts.ObservedAt.Format("15:04"))
 		}
 		if opts.OriginalFilename != nil {
 			form.AddString("originalfilename", string(*opts.OriginalFilename))
@@ -219,10 +221,10 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 }
 
 type ListChangedLabResultsOptions struct {
-	ShowPortalOnly             *bool     `json:"showportalonly"`
-	LeaveUnprocessed           *bool     `json:"leaveunprocessed"`
-	ShowProcessedEndDateTime   time.Time `json:"showprocessedenddatetime"`
-	ShowProcessedStartDateTime time.Time `json:"showprocessedstartdatetime"`
+	ShowPortalOnly             *bool
+	LeaveUnprocessed           *bool
+	ShowProcessedEndDateTime   time.Time
+	ShowProcessedStartDateTime time.Time
 
 	Pagination *PaginationOptions
 }

--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -145,12 +145,12 @@ func NewObservationDate(t time.Time) *observationDateTime {
 
 type AddLabResultDocumentOptions struct {
 	// AttachmentContents must be Base64 encoded
-	AttachmentContents io.Reader
-	AttachmentType     LabResultAttachmentType
-	InternalNote       *string
-	NoteToPatient      *string
-	ObservedAt         *observationDateTime
-	OriginalFilename   *string
+	AttachmentContents  io.Reader
+	AttachmentType      LabResultAttachmentType
+	InternalNote        *string
+	NoteToPatient       *string
+	ObservationDateTime *observationDateTime
+	OriginalFilename    *string
 	// 1 = high, 2 = normal
 	Priority    *string
 	ResultNotes *string
@@ -199,10 +199,10 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 		if opts.NoteToPatient != nil {
 			form.AddString("notetopatient", string(*opts.NoteToPatient))
 		}
-		if opts.ObservedAt != nil {
-			form.AddString("observationdate", opts.ObservedAt.t.Format("01/02/2006"))
-			if opts.ObservedAt.includeTime {
-				form.AddString("observationtime", opts.ObservedAt.t.Format("15:04"))
+		if opts.ObservationDateTime != nil {
+			form.AddString("observationdate", opts.ObservationDateTime.t.Format("01/02/2006"))
+			if opts.ObservationDateTime.includeTime {
+				form.AddString("observationtime", opts.ObservationDateTime.t.Format("15:04"))
 			}
 		}
 		if opts.OriginalFilename != nil {

--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -128,15 +128,27 @@ const (
 	LabResultAttachmentTypeTIFF LabResultAttachmentType = "TIFF"
 )
 
+type observationDateTime struct {
+	t           time.Time
+	includeTime bool
+}
+
+func NewObservationDateTime(t time.Time) *observationDateTime {
+	return &observationDateTime{t, true}
+}
+
+func NewObservationDate(t time.Time) *observationDateTime {
+	return &observationDateTime{t, false}
+}
+
 type AddLabResultDocumentOptions struct {
 	// AttachmentContents must be Base64 encoded
 	AttachmentContents io.Reader
 	AttachmentType     LabResultAttachmentType
 	InternalNote       *string
 	NoteToPatient      *string
-	// Sets both observationdate and observationtime if not nil
-	ObservedAt       *time.Time
-	OriginalFilename *string
+	ObservedAt         *observationDateTime
+	OriginalFilename   *string
 	// 1 = high, 2 = normal
 	Priority    *string
 	ResultNotes *string
@@ -186,8 +198,10 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 			form.AddString("notetopatient", string(*opts.NoteToPatient))
 		}
 		if opts.ObservedAt != nil {
-			form.AddString("observationdate", opts.ObservedAt.Format("01/02/2006"))
-			form.AddString("observationtime", opts.ObservedAt.Format("15:04"))
+			form.AddString("observationdate", opts.ObservedAt.t.Format("01/02/2006"))
+			if opts.ObservedAt.includeTime {
+				form.AddString("observationtime", opts.ObservedAt.t.Format("15:04"))
+			}
 		}
 		if opts.OriginalFilename != nil {
 			form.AddString("originalfilename", string(*opts.OriginalFilename))

--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -124,6 +124,7 @@ const (
 	LabResultAttachmentTypeJPG  LabResultAttachmentType = "JPG"
 	LabResultAttachmentTypeJPEG LabResultAttachmentType = "JPEG"
 	LabResultAttachmentTypePDF  LabResultAttachmentType = "PDF"
+	LabResultAttachmentTypePNG  LabResultAttachmentType = "PNG"
 	LabResultAttachmentTypeTIF  LabResultAttachmentType = "TIF"
 	LabResultAttachmentTypeTIFF LabResultAttachmentType = "TIFF"
 )

--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -133,10 +133,12 @@ type observationDateTime struct {
 	includeTime bool
 }
 
+// NewObservationDate sets `observationdate` & `observationtime`
 func NewObservationDateTime(t time.Time) *observationDateTime {
 	return &observationDateTime{t, true}
 }
 
+// NewObservationDate sets only `observationdate`
 func NewObservationDate(t time.Time) *observationDateTime {
 	return &observationDateTime{t, false}
 }

--- a/athenahealth/lab_results_test.go
+++ b/athenahealth/lab_results_test.go
@@ -106,9 +106,9 @@ func TestHTTPClient_AddLabResultDocument(t *testing.T) {
 
 	b := bytes.NewReader([]byte(`test bytes`))
 	res, err := athenaClient.AddLabResultDocumentReader(ctx, patientID, departmentID, &AddLabResultDocumentOptions{
-		AttachmentContents: b,
-		AttachmentType:     LabResultAttachmentTypeJPG,
-		ObservedAt:         NewObservationDateTime(observedAt),
+		AttachmentContents:  b,
+		AttachmentType:      LabResultAttachmentTypeJPG,
+		ObservationDateTime: NewObservationDateTime(observedAt),
 	})
 
 	assert.NoError(err)
@@ -145,9 +145,9 @@ func TestHTTPClient_AddLabResultDocument_observation_without_time(t *testing.T) 
 
 	b := bytes.NewReader([]byte(`test bytes`))
 	res, err := athenaClient.AddLabResultDocumentReader(ctx, patientID, departmentID, &AddLabResultDocumentOptions{
-		AttachmentContents: b,
-		AttachmentType:     LabResultAttachmentTypeJPG,
-		ObservedAt:         NewObservationDate(observedAt),
+		AttachmentContents:  b,
+		AttachmentType:      LabResultAttachmentTypeJPG,
+		ObservationDateTime: NewObservationDate(observedAt),
 	})
 
 	assert.NoError(err)

--- a/athenahealth/lab_results_test.go
+++ b/athenahealth/lab_results_test.go
@@ -84,11 +84,18 @@ func TestHTTPClient_AddLabResultDocument(t *testing.T) {
 	patientID := "123"
 	departmentID := "456"
 
+	observedAt := time.Date(2023, 9, 6, 16, 41, 3, 0, time.UTC)
+
 	h := func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
 		assert.NoError(err)
 		assert.Equal(departmentID, r.Form.Get("departmentid"))
 		assert.Equal(string(LabResultAttachmentTypeJPG), r.Form.Get("attachmenttype"))
+
+		obsDate := r.Form.Get("observationdate")
+		assert.Equal("09/06/2023", obsDate)
+		obsTime := r.Form.Get("observationtime")
+		assert.Equal("16:41", obsTime)
 
 		b, _ := os.ReadFile("./resources/AddLabResultDocument.json")
 		w.Write(b)
@@ -101,6 +108,7 @@ func TestHTTPClient_AddLabResultDocument(t *testing.T) {
 	res, err := athenaClient.AddLabResultDocumentReader(ctx, patientID, departmentID, &AddLabResultDocumentOptions{
 		AttachmentContents: b,
 		AttachmentType:     LabResultAttachmentTypeJPG,
+		ObservedAt:         &observedAt,
 	})
 
 	assert.NoError(err)


### PR DESCRIPTION
## Add observationtime to lab result

Introduces a type `observationDateTime` with two constructors. One constructors allows setting of `observationdate` without time while the other enables setting `observationdate` & `observationtime`. Both constructors follow the same interface for ease of interaction.

## Breaking Changes

This PR breaks the lab result creation interface by removing a field and introducing a new one
