### PR TITLE
Return error if present on changed lab result pull

### DIFF
--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -336,9 +336,12 @@ func (h *HTTPClient) ListChangedLabResults(ctx context.Context, opts *ListChange
 	out := &listChangedLabResultsResponse{}
 
 	_, err := h.Get(ctx, "labresults/changed", q, out)
+	if err != nil {
+		return nil, err
+	}
 
 	return &ListChangedLabResultsResult{
 		ChangedLabResults: out.LabResults,
 		Pagination:        makePaginationResult(out.Next, out.Previous, out.TotalCount),
-	}, err
+	}, nil
 }


### PR DESCRIPTION
## Return error if GET changed lab results errors

Previously we were attempting to return an error as well as access properties on a response body that might not exist in an error case.

## Breaking Changes

None, fixes existing issue