### PR TITLE
Use redis 9 and UniversalClient interface

### DIFF
--- a/athenahealth/ratelimiter/redis.go
+++ b/athenahealth/ratelimiter/redis.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/go-redis/redis_rate/v9"
+	"github.com/go-redis/redis_rate/v10"
+	"github.com/redis/go-redis/v9"
 )
 
 const redisKeyPreview = "athena_rate_limit:preview"
@@ -15,14 +15,14 @@ const defaultRatePerSecPreview = 5
 const defaultRatePerSecProd = 100
 
 type Redis struct {
-	client  *redis.Client
+	client  redis.UniversalClient
 	limiter *redis_rate.Limiter
 
 	ratePreivew int
 	rateProd    int
 }
 
-func NewRedis(client *redis.Client, ratePreview, rateProd int) *Redis {
+func NewRedis(client redis.UniversalClient, ratePreview, rateProd int) *Redis {
 	if client == nil {
 		panic("client is nil")
 	}

--- a/athenahealth/ratelimiter/redis_test.go
+++ b/athenahealth/ratelimiter/redis_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/athenahealth/tokencacher/redis.go
+++ b/athenahealth/tokencacher/redis.go
@@ -5,17 +5,17 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 )
 
 const RedisDefaultKey = "athena_token"
 
 type Redis struct {
-	client *redis.Client
+	client redis.UniversalClient
 	key    string
 }
 
-func NewRedis(client *redis.Client, key string) *Redis {
+func NewRedis(client redis.UniversalClient, key string) *Redis {
 	if client == nil {
 		panic("client is nil")
 	}

--- a/athenahealth/tokencacher/redis_test.go
+++ b/athenahealth/tokencacher/redis_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,11 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/go-redis/redis_rate/v10 v10.0.1 // indirect
 	github.com/gomodule/redigo v1.8.9 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.2.1 // indirect
 	github.com/yuin/gopher-lua v1.1.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
+github.com/go-redis/redis_rate/v10 v10.0.1 h1:calPxi7tVlxojKunJwQ72kwfozdy25RjA0bCj1h0MUo=
+github.com/go-redis/redis_rate/v10 v10.0.1/go.mod h1:EMiuO9+cjRkR7UvdvwMO7vbgqJkltQHtwbdIQvaBKIU=
 github.com/go-redis/redis_rate/v9 v9.1.2 h1:H0l5VzoAtOE6ydd38j8MCq3ABlGLnvvbA1xDSVVCHgQ=
 github.com/go-redis/redis_rate/v9 v9.1.2/go.mod h1:oam2de2apSgRG8aJzwJddXbNu91Iyz1m8IKJE2vpvlQ=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -45,6 +47,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.2.1 h1:WlYJg71ODF0dVspZZCpYmoF1+U1Jjk9Rwd7pq6QmlCg=
+github.com/redis/go-redis/v9 v9.2.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=


### PR DESCRIPTION
## Update redis to v9 and use abstract interface for clients

At present callers must use the specific redis v8 client. Accepting the [UniversalClient interface](https://pkg.go.dev/github.com/go-redis/redis/v9#UniversalClient) instead of the concrete *redis.Client allows for callers to use v8 or v9 as desired.

## Breaking Changes

Should not be a breaking change - the interface should support v8 usage as explicitly enforced prior