### PR TITLE
Revert "Add SubscribeLabResults method (#125)"

### DIFF
--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -104,7 +104,6 @@ type Client interface {
 
 	AddLabResultDocumentReader(ctx context.Context, patientID string, departmentID string, opts *AddLabResultDocumentOptions) (int, error)
 	ListLabResults(ctx context.Context, patientID string, departmentID string, opts *ListLabResultsOptions) (*ListLabResultsResult, error)
-	SubscribeLabResults(ctx context.Context) (*ErrorMessageResponse, error)
 	ListChangedLabResults(ctx context.Context, opts *ListChangedLabResultsOptions) (*ListChangedLabResultsResult, error)
 }
 

--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -345,22 +345,3 @@ func (h *HTTPClient) ListChangedLabResults(ctx context.Context, opts *ListChange
 		Pagination:        makePaginationResult(out.Next, out.Previous, out.TotalCount),
 	}, nil
 }
-
-// SubscribeLabResults subscribes to lab result change events
-// Options of specific events and departments are supported, see docs.
-//
-// GET /v1/{practiceid}/labresults/changed/subscription
-//
-// https://docs.athenahealth.com/api/api-ref/document-type-lab-result#Subscribe-to-all/specific-change-events-for-lab-results
-func (h *HTTPClient) SubscribeLabResults(ctx context.Context) (*ErrorMessageResponse, error) {
-	form := NewFormURLEncoder()
-
-	out := &ErrorMessageResponse{}
-
-	_, err := h.PostFormReader(ctx, "labresults/changed/subscription", form, out)
-	if err != nil {
-		return nil, err
-	}
-
-	return out, nil
-}

--- a/athenahealth/lab_results_test.go
+++ b/athenahealth/lab_results_test.go
@@ -180,23 +180,3 @@ func TestHTTPClient_ListChangedLabResults(t *testing.T) {
 	assert.Len(labResults, 3)
 	assert.Equal(res.Pagination.TotalCount, 3)
 }
-
-func TestHTTPClient_SubscribeLabResults(t *testing.T) {
-	assert := assert.New(t)
-
-	ctx := context.Background()
-
-	h := func(w http.ResponseWriter, r *http.Request) {
-		b, _ := os.ReadFile("./resources/SubscribeLabResults.json")
-		w.Write(b)
-	}
-
-	athenaClient, ts := testClient(h)
-	defer ts.Close()
-
-	res, err := athenaClient.SubscribeLabResults(ctx)
-
-	assert.NoError(err)
-	assert.True(res.Success)
-}
-

--- a/athenahealth/resources/SubscribeLabResults.json
+++ b/athenahealth/resources/SubscribeLabResults.json
@@ -1,3 +1,0 @@
-{
-  "success": true
-}


### PR DESCRIPTION
This reverts commit 17e658c0e8824b758341884e8863531d973dcd7e.

## Revert Add SubscribeLabResults

client already has generic method to handle subscriptions: `Subscribe` use that instead

## Breaking Changes

if using yesterdays version `17e658c0e88`, this PR will remove that method.