### PR TITLE
Adds the UpdatePatientMedicationHistoryConsent function

### DIFF
--- a/athenahealth/client.go
+++ b/athenahealth/client.go
@@ -16,6 +16,7 @@ type Client interface {
 	ListPatients(context.Context, *ListPatientsOptions) (*ListPatientsResult, error)
 	UpdatePatient(ctx context.Context, patientID string, opts *UpdatePatientOptions) (*UpdatePatientResult, error)
 	UpdatePatientInformationVerificationDetails(ctx context.Context, patientID string, opts *UpdatePatientInformationVerificationDetailsOptions) error
+	UpdatePatientMedicationHistoryConsent(ctx context.Context, patientID string, opts *UpdatePatientMedicationHistoryConsentOptions) error
 
 	ListSocialHistoryTemplates(context.Context) ([]*SocialHistoryTemplate, error)
 	GetPatientSocialHistory(ctx context.Context, patientID string, opts *GetPatientSocialHistoryOptions) (*GetPatientSocialHistoryResponse, error)

--- a/athenahealth/patients.go
+++ b/athenahealth/patients.go
@@ -686,6 +686,46 @@ func (h *HTTPClient) UpdatePatientInformationVerificationDetails(ctx context.Con
 	return nil
 }
 
+type UpdatePatientMedicationHistoryConsentOptions struct {
+	DepartmentID      int
+	SignatureDatetime time.Time
+	SignatureName     string
+}
+
+type updatePatientMedicationHistoryConsentResponse struct {
+	Success bool `json:"success"`
+}
+
+// UpdatePatientMedicationHistoryConsent - Update patient's medication history consent flag as having been verified
+//
+// POST /v1/{practiceid}/patients/{patientid}/medicationhistoryconsentverified
+//
+// https://docs.athenahealth.com/api/api-ref/medication-history-consent
+func (h *HTTPClient) UpdatePatientMedicationHistoryConsent(ctx context.Context, patientID string, opts *UpdatePatientMedicationHistoryConsentOptions) error {
+	out := []*updatePatientMedicationHistoryConsentResponse{}
+	var form url.Values
+
+	if opts != nil {
+		form = url.Values{}
+
+		form.Add("departmentid", strconv.Itoa(opts.DepartmentID))
+
+		form.Add("signaturedatetime", opts.SignatureDatetime.Format("01/02/2006 15:04:05"))
+		form.Add("signaturename", opts.SignatureName)
+	}
+
+	_, err := h.PostForm(ctx, fmt.Sprintf("/patients/%s/medicationhistoryconsentverified", patientID), form, &out)
+	if err != nil {
+		return err
+	}
+
+	if len(out) != 1 || !out[0].Success {
+		return errors.New("unexpected response")
+	}
+
+	return nil
+}
+
 // GetPatientCustomFields - Get custom fields information for a specific patient
 //
 // GET /v1/{practiceid}/patients/{patientid}/customfields

--- a/athenahealth/patients_test.go
+++ b/athenahealth/patients_test.go
@@ -201,7 +201,7 @@ func TestHTTPClient_UpdatePatientMedicationHistoryConsent(t *testing.T) {
 	assert := assert.New(t)
 
 	deptID := 1
-	signatureDatetime := time.Now()
+	signatureDatetime := time.Date(2022, 2, 25, 0, 0, 0, 0, time.UTC)
 	signatureName := "John Smith"
 
 	h := func(w http.ResponseWriter, r *http.Request) {

--- a/athenahealth/patients_test.go
+++ b/athenahealth/patients_test.go
@@ -197,6 +197,39 @@ func TestHTTPClient_UpdatePatientInformationVerificationDetails(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestHTTPClient_UpdatePatientMedicationHistoryConsent(t *testing.T) {
+	assert := assert.New(t)
+
+	deptID := 1
+	signatureDatetime := time.Now()
+	signatureName := "John Smith"
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(r.ParseForm())
+
+		assert.Contains(r.URL.Path, "/patients/123/")
+
+		assert.Equal(strconv.Itoa(deptID), r.FormValue("departmentid"))
+		assert.Equal(signatureDatetime.Format("01/02/2006 15:04:05"), r.FormValue("signaturedatetime"))
+		assert.Equal(signatureName, r.FormValue("signaturename"))
+
+		b, _ := os.ReadFile("./resources/UpdatePatientMedicationHistoryConsent.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	opts := &UpdatePatientMedicationHistoryConsentOptions{
+		DepartmentID:      deptID,
+		SignatureDatetime: signatureDatetime,
+		SignatureName:     signatureName,
+	}
+
+	err := athenaClient.UpdatePatientMedicationHistoryConsent(context.Background(), "123", opts)
+	assert.NoError(err)
+}
+
 func TestHTTPClient_GetPatientCustomFields(t *testing.T) {
 	assert := assert.New(t)
 

--- a/athenahealth/resources/UpdatePatientMedicationHistoryConsent.json
+++ b/athenahealth/resources/UpdatePatientMedicationHistoryConsent.json
@@ -1,0 +1,5 @@
+[
+    {
+        "success": true
+    }
+]


### PR DESCRIPTION
## Add UpdatePatientMedicationHistoryConsent function

Adds a new function to support a post call to `/v1/{practiceid}/patients/{patientid}/medicationhistoryconsentverified`

## Breaking Changes

None
