### PR TITLE
Adds the DeleteClinicalDocument function

### DIFF
--- a/athenahealth/documents.go
+++ b/athenahealth/documents.go
@@ -585,3 +585,26 @@ func (h *HTTPClient) AddPatientCaseDocument(ctx context.Context, patientID strin
 
 	return res.PatientCaseID, nil
 }
+
+type DeleteClinicalDocumentResponse struct {
+	ClinicalDocumentID int    `json:"clinicaldocumentid"`
+	ErrorMessage       string `json:"errormessage"`
+	Success            bool   `json:"success"`
+}
+
+// DeleteClinicalDocument - Mark patient's clinical document as deleted
+//
+// DELETE /v1/{practiceid}/patients/{patientid}/documents/clinicaldocument/{clinicaldocumentid}
+//
+// https://docs.athenahealth.com/api/api-ref/document-type-clinical-document#Mark-patient's-clinical-document-as-deleted
+func (h *HTTPClient) DeleteClinicalDocument(ctx context.Context, patientID string, clinicalDocumentID string) (*DeleteClinicalDocumentResponse, error) {
+
+	res := &DeleteClinicalDocumentResponse{}
+
+	_, err := h.Delete(ctx, fmt.Sprintf("/patients/%s/documents/clinicaldocument/%s", patientID, clinicalDocumentID), nil, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/athenahealth/documents_test.go
+++ b/athenahealth/documents_test.go
@@ -241,3 +241,23 @@ func TestHTTPClient_AddPatientCaseDocument(t *testing.T) {
 
 	assert.Equal(491696, patientCaseID)
 }
+
+func TestHTTPClient_DeleteClinicalDocument(t *testing.T) {
+	assert := assert.New(t)
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(r.URL.Path, "/patients/123/documents/clinicaldocument/101")
+
+		b, _ := os.ReadFile("./resources/DeleteClinicalDocument.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	res, err := athenaClient.DeleteClinicalDocument(context.Background(), "123", "101")
+
+	assert.True(res.Success)
+	assert.Equal(res.ClinicalDocumentID, 101)
+	assert.NoError(err)
+}

--- a/athenahealth/resources/DeleteClinicalDocument.json
+++ b/athenahealth/resources/DeleteClinicalDocument.json
@@ -1,0 +1,4 @@
+{
+    "success": true,
+    "clinicaldocumentid": 101
+}


### PR DESCRIPTION
## Add DeleteClinicalDocument function

Adds a new function to support a DELETE call to `/v1/{practiceid}/patients/{patientid}/documents/clinicaldocument/{clinicaldocumentid}`

## Breaking Changes

None
