### PR TITLE
fix(athenahealth/claims): correct typo on ClaimCreatedDate

### DIFF
--- a/athenahealth/claims.go
+++ b/athenahealth/claims.go
@@ -141,7 +141,7 @@ type ClaimDiagnosis struct {
 
 type Claim struct {
 	Procedures        []ClaimProcedure   `json:"procedures"`
-	ClaimCeatedDate   string             `json:"claimcreateddate"`
+	ClaimCreatedDate  string             `json:"claimcreateddate"`
 	BilledProviderID  int                `json:"billedproviderid"`
 	ClaimID           string             `json:"claimid"`
 	BilledServiceDate string             `json:"billedservicedate"`


### PR DESCRIPTION
## correct typo on ClaimCreatedDate

Please include a brief description of changes made and rationale here.

## Breaking Changes

`Claim.ClaimCeatedDate` renamed to `Claim.ClaimCreatedDate`
