### PR TITLE
feat(prescriptions): add prescriptions changed subscription

### DIFF
--- a/athenahealth/prescriptions.go
+++ b/athenahealth/prescriptions.go
@@ -1,0 +1,94 @@
+package athenahealth
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type ListChangedPrescriptionsOptions struct {
+	LeaveUnprocessed           *bool
+	ShowProcessedEndDatetime   time.Time
+	ShowProcessedStartDatetime time.Time
+
+	Pagination *PaginationOptions
+}
+
+type ChangedPrescription struct {
+	AdministerYN                string `json:"administeryn"`
+	ApprovedBy                  string `json:"approvedby"`
+	ApprovedTimestamp           string `json:"approvedtimestamp"`
+	AssignedUser                string `json:"assigneduser"`
+	Class                       string `json:"class"`
+	ClassDescription            string `json:"classdescription"`
+	ClinicalOrderTypeID         int    `json:"clinicalordertypeid"`
+	ClinicalProviderOrderTypeID int    `json:"clinicalproviderordertypeid"`
+	DateOrdered                 string `json:"dateordered"`
+	DeniedBy                    string `json:"deniedby"`
+	DeniedTimestamp             string `json:"deniedtimestamp"`
+	DepartmentID                int    `json:"departmentid"`
+	Description                 string `json:"description"`
+	DocumentationOnly           string `json:"documentationonly"`
+	DocumentID                  int    `json:"documentid"`
+	EncounterID                 int    `json:"encounterid"`
+	ExternalNote                string `json:"externalnote"`
+	OrderGenusName              string `json:"ordergenusname"`
+	OrderingProvider            string `json:"orderingprovider"`
+	OutOfNetworkReason          string `json:"outofnetworkreason"`
+	PatientID                   int    `json:"patientid"`
+	Status                      string `json:"status"`
+}
+
+type listChangedPrescriptionsResponse struct {
+	ChangedPrescriptions []*ChangedPrescription `json:"prescriptions"`
+
+	*PaginationResponse
+}
+
+type ListChangedPrescriptionsResult struct {
+	ChangedPrescriptions []*ChangedPrescription `json:"changedprescriptions"`
+
+	Pagination *PaginationResult
+}
+
+// ListChangedPrescriptions - List of changes in prescriptions based on subscribed events
+//
+// GET /v1/{practiceid}/prescriptions/changed
+//
+// https://docs.athenahealth.com/api/api-ref/document-type-prescription#Get-list-of-changes-in-prescriptions
+func (h *HTTPClient) ListChangedPrescriptions(ctx context.Context, opts *ListChangedPrescriptionsOptions) (*ListChangedPrescriptionsResult, error) {
+	q := url.Values{}
+
+	if opts != nil {
+		if opts.LeaveUnprocessed != nil {
+			q.Add("leaveunprocessed", strconv.FormatBool(*opts.LeaveUnprocessed))
+		}
+		if !opts.ShowProcessedEndDatetime.IsZero() {
+			q.Add("showprocessedenddatetime", opts.ShowProcessedEndDatetime.Format("01/02/2006 15:04:05"))
+		}
+		if !opts.ShowProcessedStartDatetime.IsZero() {
+			q.Add("showprocessedstartdatetime", opts.ShowProcessedStartDatetime.Format("01/02/2006 15:04:05"))
+		}
+		if opts.Pagination != nil {
+			if opts.Pagination.Limit > 0 {
+				q.Add("limit", strconv.Itoa(opts.Pagination.Limit))
+			}
+
+			if opts.Pagination.Offset > 0 {
+				q.Add("offset", strconv.Itoa(opts.Pagination.Offset))
+			}
+		}
+	}
+	out := &listChangedPrescriptionsResponse{}
+
+	_, err := h.Get(ctx, "/prescriptions/changed", q, out)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListChangedPrescriptionsResult{
+		ChangedPrescriptions: out.ChangedPrescriptions,
+		Pagination:           makePaginationResult(out.Next, out.Previous, out.TotalCount),
+	}, nil
+}

--- a/athenahealth/prescriptions.go
+++ b/athenahealth/prescriptions.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ListChangedPrescriptionsOptions struct {
-	LeaveUnprocessed           *bool
+	LeaveUnprocessed           bool
 	ShowProcessedEndDatetime   time.Time
 	ShowProcessedStartDatetime time.Time
 
@@ -29,7 +29,7 @@ type ChangedPrescription struct {
 	DeniedTimestamp             string `json:"deniedtimestamp"`
 	DepartmentID                int    `json:"departmentid"`
 	Description                 string `json:"description"`
-	DocumentationOnly           string `json:"documentationonly"`
+	DocumentationOnly           bool   `json:"documentationonly"`
 	DocumentID                  int    `json:"documentid"`
 	EncounterID                 int    `json:"encounterid"`
 	ExternalNote                string `json:"externalnote"`
@@ -61,8 +61,8 @@ func (h *HTTPClient) ListChangedPrescriptions(ctx context.Context, opts *ListCha
 	q := url.Values{}
 
 	if opts != nil {
-		if opts.LeaveUnprocessed != nil {
-			q.Add("leaveunprocessed", strconv.FormatBool(*opts.LeaveUnprocessed))
+		if opts.LeaveUnprocessed {
+			q.Add("leaveunprocessed", strconv.FormatBool(opts.LeaveUnprocessed))
 		}
 		if !opts.ShowProcessedEndDatetime.IsZero() {
 			q.Add("showprocessedenddatetime", opts.ShowProcessedEndDatetime.Format("01/02/2006 15:04:05"))

--- a/athenahealth/prescriptions_test.go
+++ b/athenahealth/prescriptions_test.go
@@ -1,0 +1,38 @@
+package athenahealth
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPClient_ListChangedPrescriptions(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	leaveUnprocessed := false
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(strconv.FormatBool(leaveUnprocessed), r.URL.Query().Get("leaveunprocessed"))
+
+		b, _ := os.ReadFile("./resources/ListChangedPrescriptions.json")
+		w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	res, err := athenaClient.ListChangedPrescriptions(ctx, &ListChangedPrescriptionsOptions{
+		LeaveUnprocessed: &leaveUnprocessed,
+	})
+	prescriptions := res.ChangedPrescriptions
+
+	assert.NoError(err)
+	assert.Len(prescriptions, 1)
+	assert.Equal(res.Pagination.TotalCount, 1)
+}

--- a/athenahealth/prescriptions_test.go
+++ b/athenahealth/prescriptions_test.go
@@ -13,9 +13,7 @@ import (
 func TestHTTPClient_ListChangedPrescriptions(t *testing.T) {
 	assert := assert.New(t)
 
-	ctx := context.Background()
-
-	leaveUnprocessed := false
+	leaveUnprocessed := true
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(strconv.FormatBool(leaveUnprocessed), r.URL.Query().Get("leaveunprocessed"))
@@ -27,12 +25,15 @@ func TestHTTPClient_ListChangedPrescriptions(t *testing.T) {
 	athenaClient, ts := testClient(h)
 	defer ts.Close()
 
-	res, err := athenaClient.ListChangedPrescriptions(ctx, &ListChangedPrescriptionsOptions{
-		LeaveUnprocessed: &leaveUnprocessed,
-	})
+	opts := &ListChangedPrescriptionsOptions{
+		LeaveUnprocessed: leaveUnprocessed,
+	}
+
+	res, err := athenaClient.ListChangedPrescriptions(context.Background(), opts)
 	prescriptions := res.ChangedPrescriptions
 
 	assert.NoError(err)
-	assert.Len(prescriptions, 1)
-	assert.Equal(res.Pagination.TotalCount, 1)
+	assert.Len(prescriptions, 3)
+	assert.Equal(3, res.Pagination.TotalCount)
+	assert.Len(prescriptions, res.Pagination.TotalCount)
 }

--- a/athenahealth/resources/ListChangedPrescriptions.json
+++ b/athenahealth/resources/ListChangedPrescriptions.json
@@ -1,29 +1,49 @@
 {
-  "totalcount": 1,
+  "totalcount": 3,
   "prescriptions": [
     {
-      "administeryn": "y",
       "approvedby": "admin",
-      "approvedtimestamp": "2025-02-10T16:00:00-06:00",
+      "approvedtimestamp": "02/13/2025 12:33 PM",
       "assigneduser": "admin",
-      "class": "Prescription",
-      "classdescription": "Prescription",
-      "clinicalordertypeid": 1,
-      "clinicalproviderordertypeid": 1,
-      "dateordered": "2025-02-10T16:00:00-06:00",
-      "deniedby": "",
-      "deniedtimestamp": "",
+      "class": "PRESCRIPTION",
+      "classdescription": "Prescription - Refill",
+      "dateordered": "02/13/2025 11:33 AM",
       "departmentid": 1,
       "description": "Prescription for Tylenol",
-      "documentationonly": "n",
+      "documentationonly": false,
       "documentid": 1,
       "encounterid": 1,
-      "externalnote": "Take with food",
-      "ordergenusname": "Tylenol",
       "orderingprovider": "admin",
-      "outofnetworkreason": "",
       "patientid": 1,
-      "status": "Approved"
+      "status": "CLOSED"
+    },
+    {
+      "departmentid": 5,
+      "dateordered": "02/13/2025 11:33 AM",
+      "documentationonly": false,
+      "patientid": 1,
+      "status": "REVIEW",
+      "assigneduser": "doctor STAFF",
+      "description": "Adderall 10 mg tablet",
+      "documentid": 2,
+      "class": "PRESCRIPTION",
+      "orderingprovider": "doctor",
+      "classdescription": "Prescription - New",
+      "encounterid": 1
+    },
+    {
+      "departmentid": 5,
+      "dateordered": "02/13/2025 11:33 AM",
+      "documentationonly": false,
+      "patientid": 1,
+      "status": "NOTIFY",
+      "assigneduser": "doctor STAFF",
+      "description": "Adderall 10 mg tablet",
+      "documentid": 2,
+      "class": "PRESCRIPTION",
+      "orderingprovider": "doctor",
+      "classdescription": "Prescription - New",
+      "encounterid": 1
     }
   ]
 }

--- a/athenahealth/resources/ListChangedPrescriptions.json
+++ b/athenahealth/resources/ListChangedPrescriptions.json
@@ -1,0 +1,29 @@
+{
+  "totalcount": 1,
+  "prescriptions": [
+    {
+      "administeryn": "y",
+      "approvedby": "admin",
+      "approvedtimestamp": "2025-02-10T16:00:00-06:00",
+      "assigneduser": "admin",
+      "class": "Prescription",
+      "classdescription": "Prescription",
+      "clinicalordertypeid": 1,
+      "clinicalproviderordertypeid": 1,
+      "dateordered": "2025-02-10T16:00:00-06:00",
+      "deniedby": "",
+      "deniedtimestamp": "",
+      "departmentid": 1,
+      "description": "Prescription for Tylenol",
+      "documentationonly": "n",
+      "documentid": 1,
+      "encounterid": 1,
+      "externalnote": "Take with food",
+      "ordergenusname": "Tylenol",
+      "orderingprovider": "admin",
+      "outofnetworkreason": "",
+      "patientid": 1,
+      "status": "Approved"
+    }
+  ]
+}


### PR DESCRIPTION
## Implementation Overview

Added support for "subscribing" to the prescription changes within Athena.
- Changed prescription model, request, and response models to match Athena and convention within the repo
- Added call to ListChangedPrescriptions Athena endpoint `/prescriptions/changed`
- Included basic unit test matching what others have done within the repo
- Added mocked/modified API responses to what I've gotten from Athena in testing

## Breaking Changes

If this PR contains breaking changes, please identify them here and provide examples of how calling code should change to accommodate changes.

- None