### PR TITLE
fix(appointments): response is not slice

### DIFF
--- a/athenahealth/appointments.go
+++ b/athenahealth/appointments.go
@@ -857,7 +857,7 @@ func (h *HTTPClient) freezeOrUnfreezeAppointmentSlot(ctx context.Context, appoin
 		Success      bool   `json:"success"`
 	}
 
-	q, out := url.Values{}, []freezeOrUnfreezeAppointmentSlotResponse{}
+	q, out := url.Values{}, freezeOrUnfreezeAppointmentSlotResponse{}
 
 	q.Set("freeze", strconv.FormatBool(freeze))
 
@@ -872,16 +872,16 @@ func (h *HTTPClient) freezeOrUnfreezeAppointmentSlot(ctx context.Context, appoin
 		return err
 	}
 
-	if !out[0].Success {
-		if strings.Contains(out[0].ErrorMessage, "already frozen") {
+	if !out.Success {
+		if strings.Contains(out.ErrorMessage, "already frozen") {
 			return ErrAppointmentSlotAlreadyFrozen
 		}
 
-		if strings.Contains(out[0].ErrorMessage, "already unfrozen") {
+		if strings.Contains(out.ErrorMessage, "already unfrozen") {
 			return ErrAppointmentSlotAlreadyUnfrozen
 		}
 
-		return errors.New(out[0].ErrorMessage)
+		return errors.New(out.ErrorMessage)
 	}
 
 	return nil

--- a/athenahealth/resources/FreezeAppointmentSlotError.json
+++ b/athenahealth/resources/FreezeAppointmentSlotError.json
@@ -1,6 +1,4 @@
-[
-  {
-    "success": false,
-    "errormessage": "oops"
-  }
-]
+{
+  "success": false,
+  "errormessage": "oops"
+}

--- a/athenahealth/resources/FreezeAppointmentSlotErrorFrozen.json
+++ b/athenahealth/resources/FreezeAppointmentSlotErrorFrozen.json
@@ -1,6 +1,4 @@
-[
-  {
-    "success": false,
-    "errormessage": "Appointment is already frozen."
-  }
-]
+{
+  "success": false,
+  "errormessage": "Appointment is already frozen."
+}

--- a/athenahealth/resources/FreezeAppointmentSlotOk.json
+++ b/athenahealth/resources/FreezeAppointmentSlotOk.json
@@ -1,6 +1,4 @@
-[
-  {
-    "success": true,
-    "errormessage": ""
-  }
-]
+{
+  "success": true,
+  "errormessage": ""
+}


### PR DESCRIPTION
## Corrects appointments freeze and unfreeze response marshaling

This response is an object, not a slice

## Breaking Changes

previous version of this method causes marshaling error, this PR fixes that.
