### PR TITLE
Making clinical document subclass optional

### DIFF
--- a/athenahealth/documents.go
+++ b/athenahealth/documents.go
@@ -283,7 +283,7 @@ type AddClinicalDocumentOptions struct {
 	// Text data stored with document
 	DocumentData *string
 	// Subclasses for CLINICALDOCUMENT documents
-	DocumentSubclass string
+	DocumentSubclass *string
 	// A specific document type identifier.
 	DocumentTypeID *int
 	// Identifier of entity creating the document. entitytype is required while passing entityid.
@@ -341,7 +341,12 @@ func (h *HTTPClient) AddClinicalDocument(ctx context.Context, patientID string, 
 			form.Add("documentdata", *opts.DocumentData)
 		}
 
-		form.Add("documentsubclass", opts.DocumentSubclass)
+		if opts.DocumentSubclass != nil {
+			form.Add("documentsubclass", *opts.DocumentSubclass)
+		} else {
+			// Magic value Athena accepts to not set a clinical document subclass
+			form.Add("documentsubclass", "CLINICALDOCUMENT")
+		}
 
 		if opts.DocumentTypeID != nil {
 			form.Add("documenttypeid", strconv.Itoa(*opts.DocumentTypeID))

--- a/athenahealth/documents_test.go
+++ b/athenahealth/documents_test.go
@@ -169,7 +169,7 @@ func TestHTTPClient_AddClinicalDocument(t *testing.T) {
 		AttachmentContents: attachmentContents,
 		AutoClose:          &autoclose,
 		DepartmentID:       deptID,
-		DocumentSubclass:   documentSubclass,
+		DocumentSubclass:   &documentSubclass,
 		InternalNote:       &internalNote,
 		ProviderID:         &providerID,
 		DocumentTypeID:     &documentTypeId,


### PR DESCRIPTION
## Improve AddPatientDocument API

Athena allows for clinical documents without a subclass, both in the UI, as well as from [the documentation](https://docs.athenahealth.com/api/workflows/document-classification-guide)

> Subclassification is not necessary for [clinical documents]

However, because it's Athena, the API still requires the documentsubclass field to be set.

It looks like the original author already discovered the nasty magic string CLINICALDOCUMENT as a "default" option for the subclass for clinical documents. This change makes it so the end user doesn't have to worry about the magic string.

## Breaking Changes

Yes, changes the input to AddPatientDocument from string to pointer