### PR TITLE
feat(lab-results): add DocumentTypeID field to AddLabResultDocument options

### DIFF
--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -149,7 +149,7 @@ type AddLabResultDocumentReaderOptions struct {
 	// AttachmentContents must be Base64 encoded
 	AttachmentContents  io.Reader
 	AttachmentType      LabResultAttachmentType
-	DocumentLabel       *string
+	DocumentTypeID      *int
 	InternalNote        *string
 	NoteToPatient       *string
 	ObservationDateTime *observationDateTime
@@ -197,8 +197,8 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 		if len(opts.AttachmentType) > 0 {
 			form.AddString("attachmenttype", string(opts.AttachmentType))
 		}
-		if opts.DocumentLabel != nil {
-			form.AddString("documentlabel", *opts.DocumentLabel)
+		if opts.DocumentTypeID != nil {
+			form.AddInt("documenttypeid", *opts.DocumentTypeID)
 		}
 		if opts.InternalNote != nil {
 			form.AddString("internalnote", string(*opts.InternalNote))
@@ -246,7 +246,7 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 type AddLabResultDocumentOptions struct {
 	AttachmentContents  []byte
 	AttachmentType      LabResultAttachmentType
-	DocumentLabel       *string
+	DocumentTypeID      *int
 	InternalNote        *string
 	NoteToPatient       *string
 	ObservationDateTime *observationDateTime
@@ -286,8 +286,8 @@ func (h *HTTPClient) AddLabResultDocument(ctx context.Context, patientID string,
 		if len(opts.AttachmentType) > 0 {
 			form.Add("attachmenttype", string(opts.AttachmentType))
 		}
-		if opts.DocumentLabel != nil {
-			form.Add("documentlabel", *opts.DocumentLabel)
+		if opts.DocumentTypeID != nil {
+			form.Add("documenttypeid", strconv.Itoa(*opts.DocumentTypeID))
 		}
 		if opts.InternalNote != nil {
 			form.Add("internalnote", string(*opts.InternalNote))

--- a/athenahealth/lab_results.go
+++ b/athenahealth/lab_results.go
@@ -149,6 +149,7 @@ type AddLabResultDocumentReaderOptions struct {
 	// AttachmentContents must be Base64 encoded
 	AttachmentContents  io.Reader
 	AttachmentType      LabResultAttachmentType
+	DocumentLabel       *string
 	InternalNote        *string
 	NoteToPatient       *string
 	ObservationDateTime *observationDateTime
@@ -196,6 +197,9 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 		if len(opts.AttachmentType) > 0 {
 			form.AddString("attachmenttype", string(opts.AttachmentType))
 		}
+		if opts.DocumentLabel != nil {
+			form.AddString("documentlabel", *opts.DocumentLabel)
+		}
 		if opts.InternalNote != nil {
 			form.AddString("internalnote", string(*opts.InternalNote))
 		}
@@ -242,6 +246,7 @@ func (h *HTTPClient) AddLabResultDocumentReader(ctx context.Context, patientID s
 type AddLabResultDocumentOptions struct {
 	AttachmentContents  []byte
 	AttachmentType      LabResultAttachmentType
+	DocumentLabel       *string
 	InternalNote        *string
 	NoteToPatient       *string
 	ObservationDateTime *observationDateTime
@@ -280,6 +285,9 @@ func (h *HTTPClient) AddLabResultDocument(ctx context.Context, patientID string,
 		}
 		if len(opts.AttachmentType) > 0 {
 			form.Add("attachmenttype", string(opts.AttachmentType))
+		}
+		if opts.DocumentLabel != nil {
+			form.Add("documentlabel", *opts.DocumentLabel)
 		}
 		if opts.InternalNote != nil {
 			form.Add("internalnote", string(*opts.InternalNote))

--- a/athenahealth/lab_results_test.go
+++ b/athenahealth/lab_results_test.go
@@ -154,6 +154,41 @@ func TestHTTPClient_AddLabResultDocument_observation_without_time(t *testing.T) 
 	assert.Equal(res, 1083563)
 }
 
+func TestHTTPClient_AddLabResultDocument_with_document_label(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	patientID := "123"
+	departmentID := "456"
+	documentLabel := "Drug Screen, Urine"
+
+	observedAt := time.Date(2023, 9, 6, 16, 41, 3, 0, time.UTC)
+
+	h := func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		assert.NoError(err)
+		assert.Equal(documentLabel, r.Form.Get("documentlabel"))
+
+		b, _ := os.ReadFile("./resources/AddLabResultDocument.json")
+		_, _ = w.Write(b)
+	}
+
+	athenaClient, ts := testClient(h)
+	defer ts.Close()
+
+	b := bytes.NewReader([]byte(`test bytes`))
+	res, err := athenaClient.AddLabResultDocumentReader(ctx, patientID, departmentID, &AddLabResultDocumentReaderOptions{
+		AttachmentContents:  b,
+		AttachmentType:      LabResultAttachmentTypeJPG,
+		DocumentLabel:       &documentLabel,
+		ObservationDateTime: NewObservationDateTime(observedAt),
+	})
+
+	assert.NoError(err)
+	assert.Equal(res, 1083563)
+}
+
 func TestHTTPClient_ListChangedLabResults(t *testing.T) {
 	assert := assert.New(t)
 

--- a/athenahealth/lab_results_test.go
+++ b/athenahealth/lab_results_test.go
@@ -154,21 +154,21 @@ func TestHTTPClient_AddLabResultDocument_observation_without_time(t *testing.T) 
 	assert.Equal(res, 1083563)
 }
 
-func TestHTTPClient_AddLabResultDocument_with_document_label(t *testing.T) {
+func TestHTTPClient_AddLabResultDocument_with_document_type_id(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
 
 	patientID := "123"
 	departmentID := "456"
-	documentLabel := "Drug Screen, Urine"
+	documentTypeID := 440583
 
 	observedAt := time.Date(2023, 9, 6, 16, 41, 3, 0, time.UTC)
 
 	h := func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
 		assert.NoError(err)
-		assert.Equal(documentLabel, r.Form.Get("documentlabel"))
+		assert.Equal("440583", r.Form.Get("documenttypeid"))
 
 		b, _ := os.ReadFile("./resources/AddLabResultDocument.json")
 		_, _ = w.Write(b)
@@ -181,7 +181,7 @@ func TestHTTPClient_AddLabResultDocument_with_document_label(t *testing.T) {
 	res, err := athenaClient.AddLabResultDocumentReader(ctx, patientID, departmentID, &AddLabResultDocumentReaderOptions{
 		AttachmentContents:  b,
 		AttachmentType:      LabResultAttachmentTypeJPG,
-		DocumentLabel:       &documentLabel,
+		DocumentTypeID:      &documentTypeID,
 		ObservationDateTime: NewObservationDateTime(observedAt),
 	})
 


### PR DESCRIPTION
## Summary

Adds `DocumentTypeID *int` to both `AddLabResultDocumentOptions` and `AddLabResultDocumentReaderOptions`, wiring the `documenttypeid` form field in both `AddLabResultDocument` and `AddLabResultDocumentReader`.

Needed to set the document type when uploading UDS results to Athena, which sets the visible document description in the Athena UI.

## Breaking Changes

none
