### PR TITLE
fix(ci): remove unnecessary GitHub App auth from dep update workflow

### DIFF
--- a/.github/workflows/update-dependencies-go.yml
+++ b/.github/workflows/update-dependencies-go.yml
@@ -15,9 +15,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    env:
-      GOPRIVATE: github.com/eleanorhealth/*
-
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -28,16 +25,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Authenticate as GitHub App
-        id: auth-github
-        uses: eleanorhealth/github-app-installation-auth-action@v1.0.3
-        with:
-          private-key: "${{ secrets.PRIVATE_KEY }}"
-          app-id: "${{ secrets.DEPLOYER_GITHUB_APP_ID }}"
-
       - name: Configure git
         run: |
-          git config --global url."https://x-access-token:${{ steps.auth-github.outputs.github_app_token }}@github.com/eleanorhealth".insteadOf "https://github.com/eleanorhealth"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
@@ -54,12 +43,5 @@ jobs:
 
       - name: Create PR
         env:
-          # GH_TOKEN is the environment variable the gh CLI reads by default
-          # for authentication. Use the built-in GITHUB_TOKEN (not the App
-          # token) so that gh api POST /pulls is authorized. The workflow
-          # declares pull-requests: write above, which grants this token that
-          # scope. The App token is used for git push (wired in Configure git)
-          # but the GitHub App installation does not have pull-requests: write,
-          # causing HTTP 403 on every PR API call regardless of REST vs GraphQL.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bin/create-pr


### PR DESCRIPTION
go-athenahealth has no private `github.com/eleanorhealth/*` dependencies, so the GitHub App installation auth step is not needed and was causing workflow failures.

## What changed

- Removed `Authenticate as GitHub App` step (`eleanorhealth/github-app-installation-auth-action`)
- Removed `GOPRIVATE: github.com/eleanorhealth/*` job-level env var
- Removed HTTPS remote override using the app token from `Configure git`
- Removed stale comment block in `Create PR` that referenced the app token

Auth is now `GITHUB_TOKEN` only (built-in from `actions/checkout`), which is sufficient for a repo with no private Go module dependencies.

Mirrors the same fix applied to the feature-flag repo (PR #18).